### PR TITLE
Restore shared PostgreSQL test fixtures after cleanup

### DIFF
--- a/internal/store/postgres/fixtures_test.go
+++ b/internal/store/postgres/fixtures_test.go
@@ -1,0 +1,89 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/open-cluster/oc-control-plane/internal/auth/authz"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/store/postgres"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func postgresDSN(t *testing.T) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("integration test: requires a Docker daemon")
+	}
+
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, "postgres:17-alpine",
+		tcpostgres.WithDatabase("controlplane"),
+		tcpostgres.WithUsername("controlplane"),
+		tcpostgres.WithPassword("controlplane"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(2*time.Minute)),
+	)
+	if err != nil {
+		noContainerRuntime(t, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+func openDatabaseForTest(t *testing.T, dsn string) *storage.Database {
+	t.Helper()
+	opened, err := storage.OpenDatabase(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("OpenDatabase: %v", err)
+	}
+	t.Cleanup(opened.Close)
+	return opened
+}
+
+func organization(t *testing.T, id string) tenancy.Organization {
+	t.Helper()
+	value, err := tenancy.NewOrganization(id)
+	if err != nil {
+		t.Fatalf("NewOrganization(%q): %v", id, err)
+	}
+	return value
+}
+
+func ownerOf(t *testing.T, organization tenancy.Organization) authz.Principal {
+	t.Helper()
+	return memberOf(t, organization, authz.Admin)
+}
+
+func memberOf(
+	t *testing.T, organization tenancy.Organization, role authz.Role,
+) authz.Principal {
+	t.Helper()
+
+	principal, err := authz.NewPrincipal(authz.KindUser, "user-under-test", "Test Operator",
+		[]authz.Membership{{Organization: organization, Role: role}})
+	if err != nil {
+		t.Fatalf("building a principal: %v", err)
+	}
+	return principal
+}
+
+func aStranger(t *testing.T) authz.Principal {
+	t.Helper()
+
+	elsewhere, err := tenancy.NewOrganization("org-somebody-else")
+	if err != nil {
+		t.Fatalf("naming another organization: %v", err)
+	}
+	return memberOf(t, elsewhere, authz.Admin)
+}


### PR DESCRIPTION
The cleanup merged in #54 removed `storage_test.go`, including six fixture functions still used by the surviving PostgreSQL tests. The package failed compilation with undefined fixture names.

Restore only `postgresDSN`, `openDatabaseForTest`, `organization`, `ownerOf`, `memberOf`, and `aStranger` in `fixtures_test.go`. Deleted test cases and all production cleanup remain deleted or unchanged. No production behavior changes.

Validation: observed the failure on main, then passed complete root compilation and full root/nested race suites, including real PostgreSQL and the composed control plane. Lint, builds, OpenAPI/docs, architecture, vulnerability/license and secret checks passed. Independent standards/spec reviews found no actionable issues.

`make verify` was attempted. With checksum-verified task-local Helm, separate deployment verification passed Helm lint/render and the control-plane image build, then reproduced the pre-existing frontend `COPY web/` failure. That packaging defect is tracked in #48; this fixture repair neither introduces nor conceals it. GitHub CI is checked before merge.

Prerequisite repair for safely integrating #49–#53.