### PR TITLE
Separate webhook authentication and delivery quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Read the complete [alert-to-action architecture walkthrough](./ARCHITECTURE.md).
 - Customer data and Tool execution are Organization-scoped; authentication and User-owned sessions are deployment-wide.
 - Slack-origin Investigations require a verified originating thread; unavailable optional history cannot widen tool access.
 - Background cleanup removes unusable sessions in bounded passes, including before any Organization exists.
+- Webhooks have bounded preauthentication admission and separate authenticated Integration quotas; see [limits](docs/self-hosting/configuration.mdx#webhook-admission-limits).
 - Organization-scoped API requests select one active Organization with
   `X-OpenCluster-Organization`; authorization verifies membership before handlers run.
 - Users can belong to several Organizations; Organization Admins cannot replace an existing User's password or revoke their global sessions.

--- a/docs/integrations/alerting/alertmanager.mdx
+++ b/docs/integrations/alerting/alertmanager.mdx
@@ -100,7 +100,8 @@ explain the alert.
 - **`401`:** replace the configured secret with the current value. Rotated secrets stop
   working immediately.
 - **`400`:** confirm middleware has not changed Alertmanager's version 4 webhook body.
-- **`429`:** reduce delivery frequency or group alerts more aggressively.
+- **`429`:** honor `Retry-After`, reduce delivery frequency, or group alerts more aggressively.
+  See the [shared and per-Integration limits](/self-hosting/configuration#webhook-admission-limits).
 
 ## Rotate or disconnect
 

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -122,3 +122,15 @@ The shared HTTP server allows 10 seconds for headers, 30 seconds to read a reque
 30 seconds to write a response, and 60 seconds for an idle connection. Restart after a
 change, then verify `/healthz`, `/readyz`, sign-in, Organization selection, Integration
 verification, and one bounded Investigation.
+
+## Webhook admission limits
+
+Each control-plane process allows a shared burst of 600 webhook requests and restores
+10 requests per second before authentication. This protects both alert and Slack intake;
+changing an Integration identifier or forwarding header does not create fresh capacity.
+During overload, legitimate senders may also receive `429` and must honor `Retry-After`.
+
+After authentication, each Integration has a separate burst of 60 deliveries and restores
+one delivery per second. Incorrect credentials do not spend that quota. A process tracks
+at most 4,096 active Integrations; additional Integrations receive `429` until an entry
+has been idle for ten minutes. Limits are per process and multiply across replicas.

--- a/internal/webhooks/admission_test.go
+++ b/internal/webhooks/admission_test.go
@@ -1,0 +1,42 @@
+package webhooks
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWebhookAdmissionBoundsUnauthenticatedIdentifiersAcrossEndpoints(t *testing.T) {
+	router := (Handlers{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Slack:  &SlackAgent{SigningSecret: "test-signing-secret"},
+	}).Router()
+	limited := map[string]bool{}
+	for n := range 1200 {
+		path := fmt.Sprintf("/webhooks/v1/integrations/unknown-%d/alert-events", n)
+		endpoint := "alert-events"
+		if n%2 == 0 {
+			path = SlackEventsPath
+			endpoint = "slack"
+		}
+		request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{}`))
+		request.Header.Set("X-Forwarded-For", fmt.Sprintf("192.0.2.%d", n))
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code == http.StatusTooManyRequests {
+			if response.Header().Get("Retry-After") != "1" {
+				t.Fatal("admission refusal omitted Retry-After")
+			}
+			limited[endpoint] = true
+		} else if response.Code != http.StatusUnauthorized {
+			t.Fatalf("request %d = %d, want 401 or 429", n, response.Code)
+		}
+	}
+	if !limited["slack"] || !limited["alert-events"] {
+		t.Fatalf("unauthenticated admission was not bounded on both endpoints: %v", limited)
+	}
+}

--- a/internal/webhooks/intake.go
+++ b/internal/webhooks/intake.go
@@ -145,14 +145,21 @@ func (h Handlers) Router() http.Handler {
 		}
 		mux.Handle(route.Method+" "+route.Pattern, handler)
 	}
-	return mux
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if !running.deliveries.allowRequest() {
+			running.counters.countDelivery(request.Context(), dispositionRateLimited)
+			writer.Header().Set("X-Request-ID", uuid.NewString())
+			writer.Header().Set("Retry-After", "1")
+			writeStatus(writer, http.StatusTooManyRequests, "slow down")
+			return
+		}
+		mux.ServeHTTP(writer, request)
+	})
 }
 
 // deliver accepts one webhook delivery.
 //
-// The order is the point. The rate limit comes first, because it is the only defence that must
-// hold when everything after it is being abused. The body is read under its fixed bound before
-// provider verification, then the verified provider adapter is the only code allowed to parse it.
+// Integration quota is spent only after authentication, before payload normalization.
 func (h *surface) deliver(writer http.ResponseWriter, request *http.Request) {
 	ctx, cancel := context.WithTimeout(request.Context(), readTimeout)
 	defer cancel()
@@ -161,15 +168,6 @@ func (h *surface) deliver(writer http.ResponseWriter, request *http.Request) {
 
 	integrationID, ok := h.addressed(writer, request)
 	if !ok {
-		return
-	}
-	if !h.deliveries.allow(integrationID) {
-		// Shed rather than refused. The source is told to slow down, not to stop, because the
-		// alerts behind this one are real and it should still send them.
-		h.refuse(ctx, request, "rate limited")
-		h.counters.countDelivery(ctx, dispositionRateLimited)
-		writer.Header().Set("Retry-After", "1")
-		writeStatus(writer, http.StatusTooManyRequests, "slow down")
 		return
 	}
 	body, err := readBody(writer, request)
@@ -215,6 +213,14 @@ func (h *surface) deliver(writer http.ResponseWriter, request *http.Request) {
 		// indistinguishable, because telling them apart is how a caller learns which half
 		// of a guess was right.
 		writeStatus(writer, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	if !h.deliveries.allow(integration.ID) {
+		h.refuse(ctx, request, "rate limited")
+		h.counters.countDelivery(ctx, dispositionRateLimited)
+		writer.Header().Set("Retry-After", "1")
+		writeStatus(writer, http.StatusTooManyRequests, "slow down")
 		return
 	}
 
@@ -420,9 +426,8 @@ func (h *surface) refuse(ctx context.Context, request *http.Request, reason stri
 //
 // It is skipped when no Integration was found, which is both correct and what bounds it:
 // there is no tenant to attribute an unknown identifier to, so an attacker guessing
-// identifiers writes no rows at all. A rate-limited delivery is likewise not recorded —
-// the limiter runs before the Integration is resolved, deliberately, because that is the
-// defence that has to hold when everything after it is being abused.
+// identifiers writes no rows at all. Rate-limited deliveries are not recorded, so shedding
+// requests cannot amplify database writes.
 //
 // A failure to record is logged and does not change the answer. The delivery was already
 // refused and telling the source something different because our own history could not be

--- a/internal/webhooks/ratelimit.go
+++ b/internal/webhooks/ratelimit.go
@@ -18,13 +18,13 @@ const (
 	// refillInterval is how often one delivery of headroom returns, so the sustained rate is
 	// one per second.
 	refillInterval = time.Second
-	// tracked bounds how many Integrations are remembered at once. The limiter is reachable by
-	// anything that can guess an identifier, so a map keyed by whatever arrives is a memory
-	// exhaustion primitive unless it is bounded.
+	// tracked bounds authenticated Integration buckets; new entries are refused at capacity.
 	tracked = 4096
 	// idleEviction is how long an Integration is remembered after its last delivery. A bucket
 	// that has been idle this long is full, so forgetting it loses nothing.
-	idleEviction = 10 * time.Minute
+	idleEviction          = 10 * time.Minute
+	requestBurst          = 600
+	requestRefillInterval = 100 * time.Millisecond
 )
 
 // limiter sheds deliveries from an Integration that is sending faster than any real alerting
@@ -36,9 +36,10 @@ const (
 // times this rate — which is stated rather than hidden, and is the right trade until there is
 // a shared limiter worth its coordination cost.
 type limiter struct {
-	mu      sync.Mutex
-	buckets map[uuid.UUID]*bucket
-	now     func() time.Time
+	mu       sync.Mutex
+	buckets  map[uuid.UUID]*bucket
+	now      func() time.Time
+	requests bucket
 }
 
 type bucket struct {
@@ -50,7 +51,15 @@ func newLimiter(now func() time.Time) *limiter {
 	if now == nil {
 		now = time.Now
 	}
-	return &limiter{buckets: make(map[uuid.UUID]*bucket), now: now}
+	return &limiter{buckets: make(map[uuid.UUID]*bucket), now: now,
+		requests: bucket{tokens: requestBurst, last: now()}}
+}
+
+// allowRequest bounds preauthentication work without trusting caller-selected identifiers.
+func (l *limiter) allowRequest() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.requests.take(l.now(), requestBurst, requestRefillInterval)
 }
 
 // allow reports whether this Integration may deliver now, spending one unit of headroom if so.
@@ -61,26 +70,23 @@ func (l *limiter) allow(integration uuid.UUID) bool {
 	at := l.now()
 	held, known := l.buckets[integration]
 	if !known {
-		// An Integration arriving when the map is full does not get an unbounded pass and does
-		// not get refused either: sweeping first is what keeps the bound honest, and a bound
-		// that turned into a refusal would let an attacker with many identifiers deny service
-		// to every real one.
 		if len(l.buckets) >= tracked {
 			l.evictIdle(at)
 		}
 		if len(l.buckets) >= tracked {
-			// Still full after a sweep, which means this many Integrations are genuinely active.
-			// Admitting the delivery is the right failure: shedding real traffic to protect a
-			// memory bound would be the limiter causing the outage it exists to prevent.
-			return true
+			return false
 		}
 		l.buckets[integration] = &bucket{tokens: burst - 1, last: at}
 		return true
 	}
 
-	held.tokens += at.Sub(held.last).Seconds() * (float64(time.Second) / float64(refillInterval))
-	if held.tokens > burst {
-		held.tokens = burst
+	return held.take(at, burst, refillInterval)
+}
+
+func (held *bucket) take(at time.Time, capacity float64, interval time.Duration) bool {
+	held.tokens += float64(at.Sub(held.last)) / float64(interval)
+	if held.tokens > capacity {
+		held.tokens = capacity
 	}
 	held.last = at
 

--- a/internal/webhooks/ratelimit_test.go
+++ b/internal/webhooks/ratelimit_test.go
@@ -18,6 +18,29 @@ func atTime(start time.Time, elapsed *time.Duration) func() time.Time {
 	return func() time.Time { return start.Add(*elapsed) }
 }
 
+func TestLimiter_PreAuthenticationRefillsWithoutSpendingIntegrationQuota(t *testing.T) {
+	var elapsed time.Duration
+	limiter := newLimiter(atTime(time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC), &elapsed))
+	for range 600 {
+		if !limiter.allowRequest() {
+			t.Fatal("preauthentication burst refused early")
+		}
+	}
+	if limiter.allowRequest() {
+		t.Fatal("preauthentication burst was unbounded")
+	}
+	elapsed = 100 * time.Millisecond
+	if !limiter.allowRequest() || limiter.allowRequest() {
+		t.Fatal("100 milliseconds must restore one request")
+	}
+	integration := uuid.New()
+	for range 60 {
+		if !limiter.allow(integration) {
+			t.Fatal("preauthentication spent authenticated Integration quota")
+		}
+	}
+}
+
 func TestLimiter_AllowsABurstAndThenSheds(t *testing.T) {
 	t.Parallel()
 
@@ -88,31 +111,32 @@ func TestLimiter_OneIntegrationExhaustedLeavesAnotherUntouched(t *testing.T) {
 	}
 }
 
-// The map is keyed by whatever arrives, so it is a memory-exhaustion primitive unless it is
-// bounded. It is bounded by eviction rather than by refusal: refusing at the bound would let
-// anyone with many identifiers deny service to every real Integration.
-func TestLimiter_IsBoundedInMemoryAndStillAdmitsRealTraffic(t *testing.T) {
+func TestLimiter_RefusesNewIntegrationsAtCapacity(t *testing.T) {
 	t.Parallel()
 
 	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	var elapsed time.Duration
 	limiter := newLimiter(atTime(start, &elapsed))
 
-	// Far more identifiers than the bound, each delivering once — what a flood of guesses at
-	// connection identifiers would look like.
-	for range tracked * 2 {
-		limiter.allow(uuid.New())
+	known := uuid.New()
+	limiter.allow(known)
+	for range tracked - 1 {
+		if !limiter.allow(uuid.New()) {
+			t.Fatal("refused before tracking capacity")
+		}
 	}
 	if len(limiter.buckets) > tracked {
 		t.Fatalf("the limiter is tracking %d connections, above its bound of %d",
 			len(limiter.buckets), tracked)
 	}
 
-	// And a real Integration arriving after that flood is still served rather than refused to
-	// protect a memory bound.
-	if !limiter.allow(uuid.New()) {
-		t.Fatal("shedding real traffic to protect a memory bound would be the limiter causing " +
-			"the outage it exists to prevent")
+	for range burst * 2 {
+		if limiter.allow(uuid.New()) {
+			t.Fatal("untracked Integration bypassed the full limiter")
+		}
+	}
+	if !limiter.allow(known) {
+		t.Fatal("overflow consumed an existing Integration's quota")
 	}
 }
 

--- a/test/controlplane/intake_test.go
+++ b/test/controlplane/intake_test.go
@@ -394,15 +394,20 @@ func TestIntake_AuthenticatesBeforeNormalizing(t *testing.T) {
 	}
 }
 
-func TestIntake_RateLimitsBeforeParsingOrProviderAuthentication(t *testing.T) {
+func TestIntake_ForgedRequestsDoNotSpendAuthenticatedQuota(t *testing.T) {
 	plane := startIntake(t)
+	for request := 1; request <= 65; request++ {
+		if status := plane.deliver(t, "wrong-secret-long-enough", `{not-json`); status != http.StatusUnauthorized {
+			t.Fatalf("forged request %d = %d, want 401", request, status)
+		}
+	}
 	for request := 1; request <= 60; request++ {
 		if status := plane.deliver(t, intakeSecret, `{not-json`); status != http.StatusBadRequest {
 			t.Fatalf("request %d = %d before burst was consumed, want malformed", request, status)
 		}
 	}
-	if status := plane.deliver(t, "wrong-secret-long-enough", `{not-json`); status != http.StatusTooManyRequests {
-		t.Fatalf("request after burst = %d, want rate limit before auth or parsing", status)
+	if status := plane.deliver(t, intakeSecret, `{not-json`); status != http.StatusTooManyRequests {
+		t.Fatalf("authenticated request after burst = %d, want 429", status)
 	}
 }
 


### PR DESCRIPTION
Forged requests naming a real Integration previously consumed its delivery quota, and new identifiers bypassed limits once the tracking map filled. Spend Integration quota only after authentication, refuse new authenticated buckets at capacity, and bound both webhook endpoints with one preauthentication bucket independent of caller-provided identifiers and forwarding headers.

Part of #48, F12. Existing per-Integration burst/refill remains 60/1 per second. Shared preauthentication capacity is 600/10 per second per process. Overload returns 429 with Retry-After; docs describe replica behavior and shared overload.

Validation: RED/GREEN composed HTTP regression for forged quota exhaustion, capacity regression, both-endpoint admission, refill/isolation and legitimate retry deduplication pass. Full root and nested race suites, lint/build, architecture/OpenAPI/docs, vulnerability/license/secret checks, Helm and backend image build pass. GitHub check/validate/Mintlify are green. Independent Standards and Spec reviews: no actionable findings.

Full make verify retains the confirmed baseline release failure: Frontend.Dockerfile copies the removed web/ directory. Frontend image and subsequent routing verification remain incomplete. Frontend packaging is separate work; #48 remains open.