### PR TITLE
Align event payload schemas with emitted answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Every material claim links back to a numbered Tool Run. OpenCluster never execut
 states its risk, reversibility, approval requirement, and verification procedure so an on-call engineer can decide
 safely.
 
+Investigation events include the Integration display name when a Tool starts and retain
+the canonical answer, up to 4,096 Unicode characters, when the Investigation concludes.
+
 > OpenCluster is experimental pre-release software. APIs and storage may change without
 > upgrade compatibility until the first stable release; recreate pre-release databases.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1887,6 +1887,7 @@ components:
             ordinal: { type: integer, minimum: 1 }
             tool: { type: string, minLength: 1, maxLength: 512 }
             integrationId: { type: string, minLength: 1, maxLength: 512 }
+            integration: { type: string, maxLength: 512 }
             arguments: { type: object, additionalProperties: true }
             purpose: { type: string, maxLength: 512 }
             hypothesisId: { type: string, maxLength: 512 }
@@ -1941,7 +1942,7 @@ components:
           properties:
             status: { type: string, enum: [verified_cause, supported_explanation, inconclusive, answer_only] }
             findings: { type: integer, minimum: 0 }
-            summary: { type: string, maxLength: 512 }
+            summary: { type: string, maxLength: 4096 }
             stoppedBy: { type: string, enum: [tool_runs, reasoner_turns, wall_clock, stagnation, context] }
     FailedInvestigationEvent:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4197,6 +4197,9 @@ components:
               type: string
               minLength: 1
               maxLength: 512
+            integration:
+              type: string
+              maxLength: 512
             arguments:
               type: object
               additionalProperties: true
@@ -4374,7 +4377,7 @@ components:
               minimum: 0
             summary:
               type: string
-              maxLength: 512
+              maxLength: 4096
             stoppedBy:
               type: string
               enum:

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -47,6 +47,7 @@ type records struct {
 	terminalErr error
 	auditErr    error
 	eventErr    error
+	events      []investigation.Event
 	failure     string
 	stoppedBy   string
 	usage       investigation.Usage
@@ -102,8 +103,13 @@ func (r *records) ConversationOrigin(context.Context, tenancy.Organization, uuid
 	return r.origin, r.originErr
 }
 func (r *records) AppendEvent(
-	context.Context, tenancy.Organization, uuid.UUID, investigation.Event,
+	_ context.Context, _ tenancy.Organization, _ uuid.UUID, event investigation.Event,
 ) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.eventErr == nil {
+		r.events = append(r.events, event)
+	}
 	return r.eventErr
 }
 func testCatalog(t *testing.T, run func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error)) integrations.Catalog {

--- a/internal/investigation/agent/event_contract_test.go
+++ b/internal/investigation/agent/event_contract_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/integrations"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRunEmitsDocumentedToolStartedProperties(t *testing.T) {
+	store := &records{candidate: integrations.Integration{ID: uuid.New(), Type: 99, Name: "Production source"}}
+	model := &scriptedModel{next: func(call int, _ Prompt) (Completion, error) {
+		if call == 1 {
+			return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "read", Name: "stub.read",
+				Arguments: json.RawMessage(`{"purpose":"inspect source","input":{}}`)}}}, nil
+		}
+		return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "done", Name: ConcludeToolName,
+			Arguments: validConclusion(t, []int{1})}}}, nil
+	}}
+	runner := configuredTestAgent(t, store, model, testCatalog(t, func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+		return integrations.ToolResult{Summary: "available"}, nil
+	}))
+	org, _ := tenancy.NewOrganization("org-test")
+	if err := runner.Run(context.Background(), org, investigation.Investigation{ID: uuid.New(), Subject: "source"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range store.events {
+		if event.Type == investigation.EventToolStarted {
+			if event.Payload["integration"] != "Production source" {
+				t.Fatal("Tool-started event lost its Integration display name")
+			}
+			assertEventPayloadProperties(t, "ToolStartedInvestigationEvent", event.Payload)
+			return
+		}
+	}
+	t.Fatal("no Tool-started event emitted")
+}
+
+func TestRunEmitsDocumentedCanonicalAnswerLength(t *testing.T) {
+	for _, character := range []string{"a", "界"} {
+		t.Run(character, func(t *testing.T) {
+			answer := strings.Repeat(character, 4096)
+			store := &records{}
+			var document map[string]any
+			if err := json.Unmarshal(validConclusion(t, nil), &document); err != nil {
+				t.Fatal(err)
+			}
+			document["summary"] = answer
+			arguments, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			model := &scriptedModel{next: func(_ int, _ Prompt) (Completion, error) {
+				return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "done", Name: ConcludeToolName,
+					Arguments: arguments}}}, nil
+			}}
+			runner := configuredTestAgent(t, store, model, testCatalog(t, func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+				return integrations.ToolResult{}, nil
+			}))
+			org, _ := tenancy.NewOrganization("org-test")
+			if err := runner.Run(context.Background(), org, investigation.Investigation{ID: uuid.New(), Subject: "question"}); err != nil {
+				t.Fatal(err)
+			}
+			if store.conclusion.Summary != answer {
+				t.Fatal("canonical answer changed within its accepted length")
+			}
+			for _, event := range store.events {
+				if event.Type == investigation.EventConcluded {
+					if event.Payload["summary"] != store.conclusion.Summary {
+						t.Fatal("concluded event did not retain the canonical answer")
+					}
+					assertEventPayloadProperties(t, "ConcludedInvestigationEvent", event.Payload)
+					return
+				}
+			}
+			t.Fatal("no concluded event emitted")
+		})
+	}
+}
+
+func assertEventPayloadProperties(t *testing.T, name string, payload map[string]any) {
+	t.Helper()
+	contents, err := os.ReadFile("../../../api/openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]struct {
+					AdditionalProperties any      `yaml:"additionalProperties"`
+					Required             []string `yaml:"required"`
+					Properties           map[string]struct {
+						Type      string `yaml:"type"`
+						MinLength int    `yaml:"minLength"`
+						MaxLength int    `yaml:"maxLength"`
+					} `yaml:"properties"`
+				} `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(contents, &document); err != nil {
+		t.Fatal(err)
+	}
+	schema := document.Components.Schemas[name].Properties["payload"]
+	if schema.AdditionalProperties != false || len(schema.Properties) == 0 {
+		t.Fatal("expected a declared closed payload schema")
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var serialized map[string]any
+	if err := json.Unmarshal(encoded, &serialized); err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range schema.Required {
+		if _, present := serialized[required]; !present {
+			t.Errorf("%s omitted required %s", name, required)
+		}
+	}
+	for field, value := range serialized {
+		property, present := schema.Properties[field]
+		if !present {
+			t.Errorf("%s emitted undeclared property %s", name, field)
+			continue
+		}
+		if property.Type == "string" {
+			text, ok := value.(string)
+			length := utf8.RuneCountInString(text)
+			if !ok || length < property.MinLength || (property.MaxLength > 0 && length > property.MaxLength) {
+				t.Errorf("%s.%s violates its declared string bound: length=%d", name, field, length)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Strict clients reject Tool-started events because their Integration display name is absent from the closed payload schema. They also reject concluded answers longer than 512 characters even though runtime already preserves the canonical answer up to 4096 Unicode characters. Declare the optional integration field and correct the concluded summary limit; regenerate bundled OpenAPI.

Part of #48, F08. No production Go behavior, event IDs, or envelope version changes. Typed payloads, broader event validation, nested hypothesis version and terminal durability remain separate work.

Validation: actual Agent/model execution reproduces each mismatch, then passes against corrected closed-property/required-field/string-bound contracts. ASCII and multibyte 4096-character answers retain exact canonical text. Full root/nested race suites, lint/build, architecture/OpenAPI/docs, vulnerability/license/secret checks, Helm and backend image pass. Both independent reviews found no actionable issues.

Full make verify retains the confirmed baseline release failure: Frontend.Dockerfile copies missing web/. Frontend image and subsequent routing verification remain unfinished. Deployment packaging and issue #48 remain incomplete.