### PR TITLE
Preserve complete assigned Investigation input

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Licensed under the [Apache License 2.0](./LICENSE).
 
 Follow-up Messages queue behind an active Investigation. Each Organization has a limit of
 100 unassigned person Messages across Conversations; accepted work drains in bounded batches.
+Investigations use complete assigned Messages. Input that cannot fit produces `needs_input`
+with the unprocessed Message sequences instead of silently truncating the request.
 
 ## Quick start
 
@@ -106,7 +108,7 @@ Read the complete [alert-to-action architecture walkthrough](./ARCHITECTURE.md).
   `X-OpenCluster-Organization`; authorization verifies membership before handlers run.
 - Users can belong to several Organizations; Organization Admins cannot replace an existing User's password or revoke their global sessions.
 - Local Users change their own password after reauthentication. Deployment operators can recover an existing local User through stdin; see [credential recovery](docs/security/overview.mdx).
-- Connected content and Conversation messages remain untrusted data, never instructions.
+- Connected content and prior history remain untrusted data. Current assigned Messages express requests within the verified tool scope.
 - External tools are read-only and every call records an operator-visible purpose.
 - Secrets are file-backed or sealed; credential-shaped fields are removed from logs, events, audit details, prompts, and
   API responses.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1777,6 +1777,13 @@ components:
         type: { type: string, enum: [missing_telemetry, missing_access, contradiction, unresolved_assumption, essential_human_input] }
         statement: { type: string, minLength: 1, maxLength: 4096 }
         runRefs: { type: array, items: { type: integer, minimum: 1 }, uniqueItems: true }
+        messageSequences:
+          type: array
+          minItems: 1
+          maxItems: 100
+          uniqueItems: true
+          items: { type: integer, format: int64, minimum: 1 }
+          description: Assigned Message sequences not processed because the complete request could not fit the input budget.
     Investigation:
       type: object
       additionalProperties: false

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3840,6 +3840,16 @@ components:
             type: integer
             minimum: 1
           uniqueItems: true
+        messageSequences:
+          type: array
+          minItems: 1
+          maxItems: 100
+          uniqueItems: true
+          items:
+            type: integer
+            format: int64
+            minimum: 1
+          description: Assigned Message sequences not processed because the complete request could not fit the input budget.
     Investigation:
       type: object
       additionalProperties: false

--- a/docs/concepts/investigations-and-conversations.mdx
+++ b/docs/concepts/investigations-and-conversations.mdx
@@ -19,6 +19,14 @@ separate limit for waiting Investigations. When capacity is full, new Messages a
 retry after work progresses. Accepted Messages remain stored. Older backlogs larger than
 the limit drain in chronological batches of at most 100.
 
+Each Investigation receives the complete Messages assigned to it, in order, with their
+authors and timestamps. A shortened question preview does not replace those instructions.
+Optional history and inventory are omitted first if the initial request is too large.
+If the complete assigned batch still cannot fit, the result is `needs_input`: its limitation
+identifies the unprocessed Message sequences and asks you to narrow or split the request.
+Those Messages stay stored; send a new Message to continue. No part of that batch is
+reported as answered.
+
 For example, “Why did checkout latency rise?” opens one Investigation. “Does the deploy
 at 09:42 explain it?” becomes a new Message and a new bounded Investigation in the same
 Conversation, retaining prior cited Findings without changing the first result.

--- a/internal/conversation/record.go
+++ b/internal/conversation/record.go
@@ -124,9 +124,8 @@ type Conversation struct {
 	LastActivityAt time.Time
 }
 
-// Message is one thing said, at its position in the conversation. The text is untrusted
-// for its whole life: it reaches a model as evidence about what somebody typed, never as
-// an instruction.
+// Message is one thing said, at its position in the Conversation. Its text never grants
+// Integration or resource authority.
 type Message struct {
 	// Sequence is monotonic within the conversation, from one.
 	Sequence     int64

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -222,21 +222,23 @@ func (r *Agent) Run(
 		state.maxTurns = defaultMaxTurns
 	}
 	if len(messages) > 0 {
-		fits, err := r.assignedInputFits(state, oriented)
+		// UTF-8 bytes conservatively bound input tokens, with output reserved and ten percent headroom.
+		inputCapacity := state.ceiling - state.ceiling/10
+		inputBytes, err := r.initialInputBytes(oriented)
 		if err != nil {
 			return failRun("the assigned input budget could not be established", investigation.Usage{})
 		}
-		if !fits {
+		if inputBytes > inputCapacity {
 			oriented.Brief = &investigation.Brief{Turn: opened.Turn, Limitations: []string{
 				"Optional history and inventory were omitted to preserve the complete current request.",
 			}}
 			oriented.Inventory = nil
-			fits, err = r.assignedInputFits(state, oriented)
+			inputBytes, err = r.initialInputBytes(oriented)
 			if err != nil {
 				return failRun("the assigned input budget could not be established", investigation.Usage{})
 			}
 		}
-		if !fits {
+		if inputBytes > inputCapacity {
 			err := r.requestNarrowerInput(ctx, state, messages)
 			if err == nil {
 				r.RuntimeTelemetry.Ended(time.Since(startedAt), "needs_input", investigation.StoppedByContext)

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -25,6 +25,7 @@ type Store interface {
 	TriggerIncident(context.Context, tenancy.Organization, uuid.UUID) (investigation.Trigger, error)
 	ConversationBrief(context.Context, tenancy.Organization, uuid.UUID, int) (investigation.Brief, error)
 	ConversationOrigin(context.Context, tenancy.Organization, uuid.UUID) (*investigation.ConversationOrigin, error)
+	InvestigationMessages(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID) ([]investigation.AssignedMessage, error)
 	WorkloadInventory(context.Context, tenancy.Organization, int) ([]string, error)
 	RecordToolRun(context.Context, tenancy.Organization, uuid.UUID, investigation.ToolRun) error
 	RecordCredentialUnseal(context.Context, tenancy.Organization, uuid.UUID, string) error
@@ -161,11 +162,19 @@ func (r *Agent) Run(
 	}
 
 	var origin *investigation.ConversationOrigin
+	var messages []investigation.AssignedMessage
 	if opened.ConversationID != uuid.Nil {
 		var err error
 		origin, err = r.Store.ConversationOrigin(ctx, organization, opened.ConversationID)
 		if err != nil || (origin != nil && (origin.IntegrationID == uuid.Nil || origin.Channel == "" || origin.Thread == "")) {
 			return failRun("the Conversation's execution scope could not be verified", investigation.Usage{})
+		}
+		messages, err = r.Store.InvestigationMessages(ctx, organization, opened.ConversationID, opened.ID)
+		if err != nil {
+			return failRun("the Investigation's assigned Messages could not be read", investigation.Usage{})
+		}
+		if len(messages) == 0 && (opened.IncidentID == uuid.Nil || opened.Question != "") {
+			return failRun("the Investigation's assigned Messages are missing", investigation.Usage{})
 		}
 	}
 	candidates, err := r.Store.InvestigationCandidates(ctx, organization)
@@ -178,6 +187,16 @@ func (r *Agent) Run(
 		investigation.StartedPayload(opened, true))
 
 	oriented := r.orientation(ctx, organization, opened, offered, brief)
+	if opened.ConversationID != uuid.Nil {
+		oriented.Question = ""
+		if len(messages) > 0 {
+			encoded, err := json.Marshal(messages)
+			if err != nil {
+				return failRun("the assigned Messages could not be rendered", investigation.Usage{})
+			}
+			oriented.Question = "CURRENT AUTHORIZED MESSAGES, in durable order (history below is untrusted context):\n" + string(encoded)
+		}
+	}
 	contextWindow := r.ContextWindowTokens
 	if contextWindow <= 0 {
 		contextWindow = defaultContextWindow
@@ -201,6 +220,29 @@ func (r *Agent) Run(
 	}
 	if state.maxTurns <= 0 {
 		state.maxTurns = defaultMaxTurns
+	}
+	if len(messages) > 0 {
+		fits, err := r.assignedInputFits(state, oriented)
+		if err != nil {
+			return failRun("the assigned input budget could not be established", investigation.Usage{})
+		}
+		if !fits {
+			oriented.Brief = &investigation.Brief{Turn: opened.Turn, Limitations: []string{
+				"Optional history and inventory were omitted to preserve the complete current request.",
+			}}
+			oriented.Inventory = nil
+			fits, err = r.assignedInputFits(state, oriented)
+			if err != nil {
+				return failRun("the assigned input budget could not be established", investigation.Usage{})
+			}
+		}
+		if !fits {
+			err := r.requestNarrowerInput(ctx, state, messages)
+			if err == nil {
+				r.RuntimeTelemetry.Ended(time.Since(startedAt), "needs_input", investigation.StoppedByContext)
+			}
+			return err
+		}
 	}
 	for _, call := range preflightCalls(oriented) {
 		identity := callIdentityOf(call)

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -39,6 +39,8 @@ type records struct {
 	briefErr    error
 	origin      *investigation.ConversationOrigin
 	originErr   error
+	messages    []investigation.AssignedMessage
+	messagesErr error
 	runs        []investigation.ToolRun
 	unseals     int
 	toolUsed    bool
@@ -101,6 +103,10 @@ func (r *records) ConversationBrief(context.Context, tenancy.Organization, uuid.
 
 func (r *records) ConversationOrigin(context.Context, tenancy.Organization, uuid.UUID) (*investigation.ConversationOrigin, error) {
 	return r.origin, r.originErr
+}
+
+func (r *records) InvestigationMessages(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID) ([]investigation.AssignedMessage, error) {
+	return r.messages, r.messagesErr
 }
 func (r *records) AppendEvent(
 	_ context.Context, _ tenancy.Organization, _ uuid.UUID, event investigation.Event,
@@ -312,6 +318,7 @@ func TestRunScopesAProviderConversationToItsOriginThread(t *testing.T) {
 			}
 			// This adapter overrides only candidate discovery so Run sees both installations.
 			store.candidate = storeCandidates[0]
+			store.messages = []investigation.AssignedMessage{{Sequence: 1, Text: "Read this thread."}}
 			model := &scriptedModel{next: func(call int, prompt Prompt) (Completion, error) {
 				if len(prompt.Tools) != 3 || prompt.Tools[0].Name != "chat.thread" ||
 					prompt.Tools[1].Name != UpdateHypothesesToolName || prompt.Tools[2].Name != ConcludeToolName {

--- a/internal/investigation/agent/conversation_scope_test.go
+++ b/internal/investigation/agent/conversation_scope_test.go
@@ -42,7 +42,8 @@ func TestRunRefusesWhenConversationOriginCannotBeVerified(t *testing.T) {
 }
 
 func TestFirstQuestionReportsUnavailableHistoryWithoutBecomingAFollowUp(t *testing.T) {
-	store := &records{briefErr: errors.New("history unavailable")}
+	store := &records{briefErr: errors.New("history unavailable"),
+		messages: []investigation.AssignedMessage{{Sequence: 1, Text: "What changed?"}}}
 	model := &scriptedModel{next: func(_ int, prompt Prompt) (Completion, error) {
 		var rendered strings.Builder
 		for _, blocks := range [][]Block{prompt.System, prompt.Content} {

--- a/internal/investigation/agent/input.go
+++ b/internal/investigation/agent/input.go
@@ -8,17 +8,14 @@ import (
 	"github.com/open-cluster/oc-control-plane/internal/investigation"
 )
 
-func (r *Agent) assignedInputFits(state *runState, oriented orientation) (bool, error) {
-	candidate := *state
-	candidate.task = taskInstruction(oriented)
-	candidate.orientationText = renderOrientation(oriented)
-	candidate.tools = exchangeTools(oriented)
+func (r *Agent) initialInputBytes(oriented orientation) (int, error) {
+	candidate := runState{task: taskInstruction(oriented),
+		orientationText: renderOrientation(oriented), tools: exchangeTools(oriented)}
 	encoded, err := json.Marshal(modelPrompt(r, &candidate, false))
 	if err != nil {
-		return false, err
+		return 0, err
 	}
-	// UTF-8 bytes conservatively bound input tokens; reserve output and ten percent headroom.
-	return len(encoded) <= state.ceiling-state.ceiling/10, nil
+	return len(encoded), nil
 }
 
 func (r *Agent) requestNarrowerInput(ctx context.Context, state *runState, messages []investigation.AssignedMessage) error {

--- a/internal/investigation/agent/input.go
+++ b/internal/investigation/agent/input.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func (r *Agent) assignedInputFits(state *runState, oriented orientation) (bool, error) {
+	state.task = taskInstruction(oriented)
+	state.orientationText = renderOrientation(oriented)
+	state.tools = exchangeTools(oriented)
+	encoded, err := json.Marshal(modelPrompt(r, state, false))
+	if err != nil {
+		return false, err
+	}
+	// UTF-8 bytes conservatively bound input tokens; reserve output and ten percent headroom.
+	return len(encoded) <= state.ceiling-state.ceiling/10, nil
+}
+
+func (r *Agent) requestNarrowerInput(ctx context.Context, state *runState, messages []investigation.AssignedMessage) error {
+	sequences := make([]int64, len(messages))
+	for n, message := range messages {
+		sequences[n] = message.Sequence
+	}
+	const request = "The complete assigned Messages cannot fit within the input budget. Narrow or split the question and send a new Message; none of this batch was answered."
+	conclusion := investigation.Conclusion{
+		Status: investigation.Inconclusive, Summary: request,
+		Impact: investigation.ImpactAssessment{Status: investigation.ImpactUnknown, CurrentState: "unknown",
+			Summary: "Input was not processed.", AffectedServices: []string{}, AffectedUsers: []string{}, RunRefs: []int{}},
+		Findings: []investigation.Finding{}, Hypotheses: []investigation.HypothesisResult{}, Actions: []investigation.ActionProposal{},
+		Limitations: []investigation.Limitation{{Type: investigation.LimitationEssentialHumanInput,
+			Statement: request, RunRefs: []int{}, MessageSequences: sequences}},
+	}
+	writeCtx, done := terminalWriteWindow(ctx)
+	defer done()
+	if err := r.Store.ConcludeInvestigation(writeCtx, state.organization, state.opened.ID, conclusion,
+		investigation.StoppedByContext, state.usage); err != nil {
+		return fmt.Errorf("recording unprocessed input: %w", err)
+	}
+	r.announce(writeCtx, state.events, investigation.EventConcluded, investigation.ConcludedPayload(conclusion, investigation.StoppedByContext))
+	return nil
+}

--- a/internal/investigation/agent/input.go
+++ b/internal/investigation/agent/input.go
@@ -9,10 +9,11 @@ import (
 )
 
 func (r *Agent) assignedInputFits(state *runState, oriented orientation) (bool, error) {
-	state.task = taskInstruction(oriented)
-	state.orientationText = renderOrientation(oriented)
-	state.tools = exchangeTools(oriented)
-	encoded, err := json.Marshal(modelPrompt(r, state, false))
+	candidate := *state
+	candidate.task = taskInstruction(oriented)
+	candidate.orientationText = renderOrientation(oriented)
+	candidate.tools = exchangeTools(oriented)
+	encoded, err := json.Marshal(modelPrompt(r, &candidate, false))
 	if err != nil {
 		return false, err
 	}

--- a/internal/investigation/agent/input_test.go
+++ b/internal/investigation/agent/input_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/integrations"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestMissingAssignedInputDoesNotFallBackToQuestionPreview(t *testing.T) {
+	for name, failure := range map[string]error{"missing": nil, "unavailable": errors.New("input unavailable")} {
+		t.Run(name, func(t *testing.T) {
+			store := &records{messagesErr: failure}
+			model := &scriptedModel{next: func(_ int, _ Prompt) (Completion, error) {
+				return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "done", Name: ConcludeToolName,
+					Arguments: validConclusion(t, nil)}}}, nil
+			}}
+			runner := configuredTestAgent(t, store, model, testCatalog(t, func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+				t.Fatal("external read before required input")
+				return integrations.ToolResult{}, nil
+			}))
+			org, _ := tenancy.NewOrganization("org-test")
+			if err := runner.Run(context.Background(), org, investigation.Investigation{ID: uuid.New(), ConversationID: uuid.New(),
+				Subject: "question", Question: "truncated preview"}); err != nil {
+				t.Fatal(err)
+			}
+			if model.calls != 0 || store.status != investigation.StatusFailed {
+				t.Fatalf("missing input: model calls=%d status=%v", model.calls, store.status)
+			}
+		})
+	}
+}
+
+func TestAllAssignedSequencesAreReportedWhenBatchCannotFit(t *testing.T) {
+	store := &records{}
+	for n := range 15 {
+		store.messages = append(store.messages, investigation.AssignedMessage{Sequence: int64(n + 20), Text: strings.Repeat("界", 8192)})
+	}
+	model := &scriptedModel{next: func(_ int, _ Prompt) (Completion, error) {
+		t.Fatal("oversized batch reached model")
+		return Completion{}, nil
+	}}
+	runner := configuredTestAgent(t, store, model, testCatalog(t, func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+		t.Fatal("oversized batch triggered an external read")
+		return integrations.ToolResult{}, nil
+	}))
+	org, _ := tenancy.NewOrganization("org-test")
+	if err := runner.Run(context.Background(), org, investigation.Investigation{ID: uuid.New(), ConversationID: uuid.New(), Subject: "batch"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.conclusion.Limitations) != 1 {
+		t.Fatal("no unprocessed input limitation")
+	}
+	sequences := store.conclusion.Limitations[0].MessageSequences
+	if len(sequences) != 15 {
+		t.Fatalf("unprocessed sequences=%v", sequences)
+	}
+	for n, sequence := range sequences {
+		if sequence != int64(n+20) {
+			t.Fatalf("wrong unprocessed sequence: %v", sequences)
+		}
+	}
+}
+
+func TestAssignedBatchBeyondHistoryTailSurvivesOptionalContextTrimming(t *testing.T) {
+	store := &records{}
+	for n := range 40 {
+		store.brief.Findings = append(store.brief.Findings, investigation.PriorFinding{Statement: fmt.Sprintf("%d ", n) + strings.Repeat("old-untrusted-finding ", 50)})
+	}
+	for n := range 15 {
+		store.messages = append(store.messages, investigation.AssignedMessage{Sequence: int64(n + 1), Actor: "Operator",
+			Text: fmt.Sprintf("ordered-request-%02d", n)})
+	}
+	model := &scriptedModel{next: func(_ int, prompt Prompt) (Completion, error) {
+		var text strings.Builder
+		for _, block := range prompt.Content {
+			text.WriteString(block.Text)
+		}
+		if strings.Contains(text.String(), "old-untrusted-finding") || !strings.Contains(text.String(), "Optional history and inventory were omitted") {
+			t.Fatal("optional context was not explicitly trimmed before current input")
+		}
+		previous := -1
+		for n := range 15 {
+			at := strings.Index(text.String(), fmt.Sprintf("ordered-request-%02d", n))
+			if at <= previous {
+				t.Fatalf("assigned request %d missing or out of order", n)
+			}
+			previous = at
+		}
+		return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, nil)}}}, nil
+	}}
+	runner := configuredTestAgent(t, store, model, testCatalog(t, func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+		return integrations.ToolResult{}, nil
+	}))
+	runner.ContextWindowTokens = 40000
+	org, _ := tenancy.NewOrganization("org-test")
+	if err := runner.Run(context.Background(), org, investigation.Investigation{ID: uuid.New(), ConversationID: uuid.New(), Subject: "batch"}); err != nil {
+		t.Fatal(err)
+	}
+	if model.calls != 1 {
+		t.Fatalf("model calls=%d", model.calls)
+	}
+}

--- a/internal/investigation/message.go
+++ b/internal/investigation/message.go
@@ -1,0 +1,11 @@
+package investigation
+
+import "time"
+
+// AssignedMessage is canonical person-authored input for one Investigation.
+type AssignedMessage struct {
+	Sequence  int64     `json:"sequence"`
+	Actor     string    `json:"actor"`
+	CreatedAt time.Time `json:"createdAt"`
+	Text      string    `json:"text"`
+}

--- a/internal/investigation/result.go
+++ b/internal/investigation/result.go
@@ -134,9 +134,10 @@ var LimitationTypes = []string{
 }
 
 type Limitation struct {
-	Type      LimitationType `json:"type"`
-	Statement string         `json:"statement"`
-	RunRefs   []int          `json:"runRefs"`
+	Type             LimitationType `json:"type"`
+	Statement        string         `json:"statement"`
+	RunRefs          []int          `json:"runRefs"`
+	MessageSequences []int64        `json:"messageSequences,omitempty"`
 }
 
 // The concluding document's record bounds, enforced where it is decoded and again

--- a/internal/store/postgres/investigation_message.go
+++ b/internal/store/postgres/investigation_message.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+// InvestigationMessages reads only the person Messages assigned to this exact turn.
+func (p *Database) InvestigationMessages(ctx context.Context, org tenancy.Organization, conversationID, id uuid.UUID) ([]investigation.AssignedMessage, error) {
+	pool, err := p.Pool(org)
+	if err != nil {
+		return nil, err
+	}
+	var exists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM investigation
+		WHERE org_id = $1 AND conversation_id = $2 AND investigation_id = $3)`,
+		org.String(), conversationID, id).Scan(&exists); err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, investigation.ErrUnknown
+	}
+	rows, err := pool.Query(ctx, `SELECT sequence, actor_display, created_at, text
+		FROM conversation_message WHERE org_id = $1 AND conversation_id = $2
+		AND investigation_id = $3 AND role = 1 ORDER BY sequence LIMIT $4`,
+		org.String(), conversationID, id, maxQueuedMessages+1)
+	if err != nil {
+		return nil, fmt.Errorf("reading assigned Messages: %w", err)
+	}
+	defer rows.Close()
+	var messages []investigation.AssignedMessage
+	for rows.Next() {
+		var message investigation.AssignedMessage
+		if err := rows.Scan(&message.Sequence, &message.Actor, &message.CreatedAt, &message.Text); err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(messages) > maxQueuedMessages {
+		return nil, fmt.Errorf("assigned Message batch exceeds %d", maxQueuedMessages)
+	}
+	return messages, nil
+}

--- a/internal/store/postgres/investigation_message_test.go
+++ b/internal/store/postgres/investigation_message_test.go
@@ -1,0 +1,44 @@
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestInvestigationMessagesPreserveOnlyTheirAssignedBatch(t *testing.T) {
+	database, org, other := twoOrganizationsInOneDatabase(t)
+	chat := openConversation(t, database, org, "assigned input")
+	ctx := context.Background()
+	var want []investigation.AssignedMessage
+	for n := range 15 {
+		message := say(t, database, org, chat.ID, strings.Repeat("界", 1100)+fmt.Sprintf(" correction-%d", n))
+		want = append(want, investigation.AssignedMessage{Sequence: message.Sequence, Actor: message.ActorDisplay,
+			CreatedAt: message.CreatedAt, Text: message.Text})
+	}
+	turn, started, err := database.OpenTurn(ctx, org, chat.ID, turnWindowLead)
+	if err != nil || !started {
+		t.Fatalf("opening turn: %v %v", started, err)
+	}
+	say(t, database, org, chat.ID, "later queued request must not become current input")
+	got, err := database.InvestigationMessages(ctx, org, chat.ID, turn.InvestigationID)
+	if err != nil || len(got) != len(want) {
+		t.Fatalf("assigned Messages: count=%d err=%v", len(got), err)
+	}
+	for n := range want {
+		if got[n].Sequence != want[n].Sequence || got[n].Actor != want[n].Actor ||
+			!got[n].CreatedAt.Equal(want[n].CreatedAt) || got[n].Text != want[n].Text {
+			t.Fatalf("assigned Message %d lost ordering, attribution, time or text", n)
+		}
+	}
+	if _, err := database.InvestigationMessages(ctx, other, chat.ID, turn.InvestigationID); err == nil {
+		t.Fatal("another Organization read assigned input")
+	}
+	sibling := openConversation(t, database, org, "other Conversation")
+	if _, err := database.InvestigationMessages(ctx, org, sibling.ID, turn.InvestigationID); err == nil {
+		t.Fatal("another Conversation read assigned input")
+	}
+}

--- a/internal/store/postgres/migrations/0005_assigned_messages.sql
+++ b/internal/store/postgres/migrations/0005_assigned_messages.sql
@@ -1,0 +1,3 @@
+CREATE INDEX conversation_message_assigned_idx
+    ON conversation_message (org_id, investigation_id, conversation_id, sequence)
+    WHERE role = 1 AND investigation_id IS NOT NULL;

--- a/test/architecture/persisted_enum_test.go
+++ b/test/architecture/persisted_enum_test.go
@@ -259,6 +259,7 @@ var enumColumns = map[string]map[string][]int{
 		"role": conversationRoleValues,
 	},
 	"conversation_capacity.go": {"role": conversationRoleValues},
+	"investigation_message.go": {"role": conversationRoleValues},
 	// The ledger opens scopes only for kubernetes Integrations and excludes baselines from
 	// every change query.
 	"change_ledger.go": {

--- a/test/controlplane/canonical_input_test.go
+++ b/test/controlplane/canonical_input_test.go
@@ -1,0 +1,74 @@
+package controlplane
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+	modelagent "github.com/open-cluster/oc-control-plane/internal/investigation/agent"
+)
+
+func TestAssignedMessageBeyondPreviewReachesModel(t *testing.T) {
+	address := freeAddress(t)
+	prompts := make(chan modelagent.Prompt, 4)
+	running := startControlPlaneRunning(t, func(cfg *config.Config) {
+		cfg.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		cfg.OperatorTokenDigest = digest[:]
+		cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+	}, app.Options{Model: concludingModel{prompts: prompts}})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	request := strings.Repeat("context ", 300) + "Use the corrected region eu-west-2 and exclude eu-central-1."
+	_, turn := plane.openConversation(t, "complete request", request)
+	plane.awaitInvestigation(t, turn)
+	select {
+	case prompt := <-prompts:
+		var rendered strings.Builder
+		for _, block := range prompt.Content {
+			rendered.WriteString(block.Text)
+		}
+		if !strings.Contains(rendered.String(), request) {
+			t.Fatal("the complete assigned Message did not reach the model")
+		}
+	default:
+		t.Fatal("Investigation did not invoke the model")
+	}
+}
+
+func TestOversizedAssignedInputRequestsNarrowingWithoutCallingModel(t *testing.T) {
+	address := freeAddress(t)
+	prompts := make(chan modelagent.Prompt, 4)
+	running := startControlPlaneRunning(t, func(cfg *config.Config) {
+		cfg.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		cfg.OperatorTokenDigest = digest[:]
+		cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+		cfg.ModelContextWindowTokens = 33000
+	}, app.Options{Model: concludingModel{prompts: prompts}})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	_, turn := plane.openConversation(t, "oversized input", strings.Repeat("界", 8192))
+	final := plane.awaitInvestigation(t, turn)
+	var result struct {
+		Status      string `json:"status"`
+		Limitations []struct {
+			Type             string  `json:"type"`
+			MessageSequences []int64 `json:"messageSequences"`
+		} `json:"limitations"`
+	}
+	if err := json.Unmarshal([]byte(final), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "needs_input" || len(result.Limitations) != 1 ||
+		result.Limitations[0].Type != "essential_human_input" || len(result.Limitations[0].MessageSequences) != 1 ||
+		result.Limitations[0].MessageSequences[0] != 1 {
+		t.Fatalf("oversized input lacks an explicit persisted sequence refusal: %s", final)
+	}
+	select {
+	case <-prompts:
+		t.Fatal("model was called with input that cannot fit")
+	default:
+	}
+}


### PR DESCRIPTION
Investigations now read the complete canonical Messages assigned to them by Organization, Conversation and Investigation, instead of answering a 1024-character question preview. Required input is separate from optional history and preserves sequence, author and timestamp. A forward index supports the lookup.

Before model or external reads, conservatively measure the initial Prompt with output reserved and headroom. Trim optional history/inventory first. If the complete batch still cannot fit, persist needs_input with every unprocessed Message sequence and a request to narrow or split it.

Part of #48 sections 3/17/21. Provider-native counting, transcript recovery and the remaining phases are separate work; issue #48 remains open.

Validation: RED/GREEN composed HTTP/model regressions; PostgreSQL assignment, ordering and tenant isolation; required-input failure and over-budget regressions; final-head race tests, architecture, lint, build, OpenAPI/docs, vulnerability and license checks passed. Standards and spec reviews have no remaining findings. GitHub checks passed. Full make verify still fails at the existing frontend Dockerfile COPY web/ release-packaging defect; backend image and Helm checks passed.
