### PR TITLE
fix: include canonical answers in recent conversation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Follow-up Messages queue behind an active Investigation. Each Organization has a
 100 unassigned person Messages across Conversations; accepted work drains in bounded batches.
 Investigations use complete assigned Messages. Input that cannot fit produces `needs_input`
 with the unprocessed Message sequences instead of silently truncating the request.
+Follow-ups receive a bounded recent exchange of Messages and completed answers, with
+timestamps and source identities retained.
 
 ## Quick start
 

--- a/docs/concepts/investigations-and-conversations.mdx
+++ b/docs/concepts/investigations-and-conversations.mdx
@@ -11,6 +11,11 @@ An Investigation is one immutable evidence-gathering turn. It moves through `que
 
 A Conversation is the ordered context a person talks to. Each Message may open a new Investigation. Follow-ups reuse bounded prior Findings and citations without copying raw provider payloads or private model reasoning.
 
+Recent context includes up to 12 Messages and completed answers combined, oldest first,
+with their timestamps. Answers come from completed Investigations in this Conversation;
+another Conversation's private answers are not included. Long entries are shortened and
+marked as truncated. This bounded context is not a complete memory of the Conversation.
+
 Completed and `needs_input` Investigations never resume. Send a new Message to create the next turn.
 
 Messages sent during an active Investigation wait for its completion. An Organization can

--- a/internal/investigation/agent/exchange_test.go
+++ b/internal/investigation/agent/exchange_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/integrations"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestModelReceivesOrderedExchangeWithCanonicalAnswerIdentity(t *testing.T) {
+	answerID := uuid.New()
+	at := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	store := &records{messages: []investigation.AssignedMessage{{Sequence: 2, Text: "refresh staging"}}}
+	store.brief.Recent = []investigation.BriefMessage{
+		{FromPerson: true, Actor: "Operator", Sequence: 1, CreatedAt: at, Text: "question-marker"},
+		{CreatedAt: at.Add(time.Minute), InvestigationID: answerID, Text: "answer-marker"},
+		{FromPerson: true, Actor: "Operator", Sequence: 2, CreatedAt: at.Add(2 * time.Minute), Text: "correction-marker"},
+	}
+	model := &scriptedModel{next: func(_ int, prompt Prompt) (Completion, error) {
+		var rendered strings.Builder
+		for _, block := range prompt.Content {
+			rendered.WriteString(block.Text)
+		}
+		text := rendered.String()
+		for _, required := range []string{answerID.String(), "2026-09-06T10:01:00Z", "message 2"} {
+			if !strings.Contains(text, required) {
+				t.Fatalf("model context omitted exchange identity %q", required)
+			}
+		}
+		if strings.Index(text, "question-marker") >= strings.Index(text, "answer-marker") ||
+			strings.Index(text, "answer-marker") >= strings.Index(text, "correction-marker") {
+			t.Fatal("model context reordered the exchange")
+		}
+		return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, nil)}}}, nil
+	}}
+	runner := configuredTestAgent(t, store, model, testCatalog(t, func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+		return integrations.ToolResult{}, nil
+	}))
+	org, _ := tenancy.NewOrganization("org-test")
+	if err := runner.Run(context.Background(), org, investigation.Investigation{ID: uuid.New(), ConversationID: uuid.New(), Turn: 2, Subject: "refresh"}); err != nil {
+		t.Fatal(err)
+	}
+	if model.calls != 1 {
+		t.Fatalf("model calls=%d", model.calls)
+	}
+}

--- a/internal/investigation/agent/prompt.go
+++ b/internal/investigation/agent/prompt.go
@@ -615,7 +615,7 @@ func renderBrief(brief *investigation.Brief) string {
 	}
 
 	if len(brief.Recent) > 0 {
-		out.WriteString("\nRECENT MESSAGES, oldest first:\n")
+		out.WriteString("\nRECENT EXCHANGE, oldest first — prior answers are observations at their recorded time:\n")
 		for _, message := range brief.Recent {
 			speaker := "OpenCluster"
 			if message.FromPerson {
@@ -624,7 +624,17 @@ func renderBrief(brief *investigation.Brief) string {
 					speaker = "operator " + message.Actor
 				}
 			}
-			out.WriteString("- " + speaker + ": " + oneLine(message.Text) + "\n")
+			out.WriteString("- " + speaker)
+			if !message.CreatedAt.IsZero() {
+				out.WriteString(" at " + stamp(message.CreatedAt))
+			}
+			if message.Sequence > 0 {
+				out.WriteString(" [message " + strconv.FormatInt(message.Sequence, 10) + "]")
+			}
+			if message.InvestigationID != uuid.Nil {
+				out.WriteString(" [investigation " + message.InvestigationID.String() + "]")
+			}
+			out.WriteString(": " + oneLine(message.Text) + "\n")
 		}
 	}
 	return out.String()

--- a/internal/investigation/brief.go
+++ b/internal/investigation/brief.go
@@ -3,6 +3,9 @@ package investigation
 import (
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 // Brief is bounded durable context carried between Conversation turns. It references
@@ -35,8 +38,11 @@ type BriefMessage struct {
 	FromPerson bool
 	// Actor is who said it, for attribution. Never a credential and never an email
 	// address the model has any use for; a display name.
-	Actor string
-	Text  string
+	Actor           string
+	Text            string
+	Sequence        int64
+	CreatedAt       time.Time
+	InvestigationID uuid.UUID
 }
 
 // PriorFinding is something an earlier turn established, with its citation as a reference.

--- a/internal/store/postgres/conversation_brief.go
+++ b/internal/store/postgres/conversation_brief.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/google/uuid"
 
@@ -22,6 +23,9 @@ import (
 func (p *Database) ConversationBrief(
 	ctx context.Context, organization tenancy.Organization, id uuid.UUID, tail int,
 ) (investigation.Brief, error) {
+	if tail <= 0 || tail > investigation.BriefRecentMessages {
+		tail = investigation.BriefRecentMessages
+	}
 	found, err := p.Conversation(ctx, organization, id)
 	if err != nil {
 		return investigation.Brief{}, err
@@ -44,10 +48,32 @@ func (p *Database) ConversationBrief(
 			brief.RecentFrom = message.Sequence
 		}
 		brief.Recent = append(brief.Recent, investigation.BriefMessage{
-			FromPerson: message.Role == conversationRolePerson,
-			Actor:      message.ActorDisplay,
-			Text:       boundedRunes(message.Text, investigation.BriefMessageBound),
+			FromPerson:      message.Role == conversationRolePerson,
+			Actor:           message.ActorDisplay,
+			Text:            briefExchangeText(message.Text),
+			Sequence:        message.Sequence,
+			CreatedAt:       message.CreatedAt,
+			InvestigationID: message.InvestigationID,
 		})
+	}
+	if err = readRecentAnswers(ctx, pool, organization, id, tail, &brief); err != nil {
+		return investigation.Brief{}, err
+	}
+	sort.SliceStable(brief.Recent, func(i, j int) bool {
+		left, right := brief.Recent[i], brief.Recent[j]
+		if !left.CreatedAt.Equal(right.CreatedAt) {
+			return left.CreatedAt.Before(right.CreatedAt)
+		}
+		if left.FromPerson != right.FromPerson {
+			return left.FromPerson
+		}
+		if left.Sequence != right.Sequence {
+			return left.Sequence < right.Sequence
+		}
+		return left.InvestigationID.String() < right.InvestigationID.String()
+	})
+	if len(brief.Recent) > tail {
+		brief.Recent = brief.Recent[len(brief.Recent)-tail:]
 	}
 	if err = readOlderOperatorStatements(ctx, pool, organization, id, &brief); err != nil {
 		return investigation.Brief{}, err
@@ -57,6 +83,41 @@ func (p *Database) ConversationBrief(
 		return investigation.Brief{}, err
 	}
 	return brief, nil
+}
+
+func readRecentAnswers(ctx context.Context, pool querier, organization tenancy.Organization,
+	id uuid.UUID, limit int, brief *investigation.Brief,
+) error {
+	rows, err := pool.Query(ctx, `
+		SELECT investigation_id, concluded_at, COALESCE(conclusion->>'summary', '')
+		  FROM investigation
+		 WHERE org_id = $1 AND conversation_id = $2 AND status = 2
+		 ORDER BY turn DESC
+		 LIMIT $3`, organization.String(), id, limit)
+	if err != nil {
+		return fmt.Errorf("reading recent answers: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var answer investigation.BriefMessage
+		if err = rows.Scan(&answer.InvestigationID, &answer.CreatedAt, &answer.Text); err != nil {
+			return fmt.Errorf("scanning recent answer: %w", err)
+		}
+		answer.Text = briefExchangeText(answer.Text)
+		brief.Recent = append(brief.Recent, answer)
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("reading recent answers: %w", err)
+	}
+	return nil
+}
+
+func briefExchangeText(text string) string {
+	if len([]rune(text)) <= investigation.BriefMessageBound {
+		return text
+	}
+	const suffix = " [truncated]"
+	return boundedRunes(text, investigation.BriefMessageBound-len(suffix)) + suffix
 }
 
 func readOlderOperatorStatements(

--- a/internal/store/postgres/conversation_brief.go
+++ b/internal/store/postgres/conversation_brief.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/google/uuid"
 
@@ -56,22 +56,20 @@ func (p *Database) ConversationBrief(
 			InvestigationID: message.InvestigationID,
 		})
 	}
-	if err = readRecentAnswers(ctx, pool, organization, id, tail, &brief); err != nil {
+	answers, err := readRecentAnswers(ctx, pool, organization, id, tail)
+	if err != nil {
 		return investigation.Brief{}, err
 	}
-	sort.SliceStable(brief.Recent, func(i, j int) bool {
-		left, right := brief.Recent[i], brief.Recent[j]
-		if !left.CreatedAt.Equal(right.CreatedAt) {
-			return left.CreatedAt.Before(right.CreatedAt)
+	// Transaction timestamps can precede lock acquisition; Message sequence stays authoritative.
+	exchange := make([]investigation.BriefMessage, 0, len(brief.Recent)+len(answers))
+	for _, message := range brief.Recent {
+		for len(answers) > 0 && answers[0].CreatedAt.Before(message.CreatedAt) {
+			exchange = append(exchange, answers[0])
+			answers = answers[1:]
 		}
-		if left.FromPerson != right.FromPerson {
-			return left.FromPerson
-		}
-		if left.Sequence != right.Sequence {
-			return left.Sequence < right.Sequence
-		}
-		return left.InvestigationID.String() < right.InvestigationID.String()
-	})
+		exchange = append(exchange, message)
+	}
+	brief.Recent = append(exchange, answers...)
 	if len(brief.Recent) > tail {
 		brief.Recent = brief.Recent[len(brief.Recent)-tail:]
 	}
@@ -86,8 +84,8 @@ func (p *Database) ConversationBrief(
 }
 
 func readRecentAnswers(ctx context.Context, pool querier, organization tenancy.Organization,
-	id uuid.UUID, limit int, brief *investigation.Brief,
-) error {
+	id uuid.UUID, limit int,
+) ([]investigation.BriefMessage, error) {
 	rows, err := pool.Query(ctx, `
 		SELECT investigation_id, concluded_at, COALESCE(conclusion->>'summary', '')
 		  FROM investigation
@@ -95,21 +93,23 @@ func readRecentAnswers(ctx context.Context, pool querier, organization tenancy.O
 		 ORDER BY turn DESC
 		 LIMIT $3`, organization.String(), id, limit)
 	if err != nil {
-		return fmt.Errorf("reading recent answers: %w", err)
+		return nil, fmt.Errorf("reading recent answers: %w", err)
 	}
 	defer rows.Close()
+	var answers []investigation.BriefMessage
 	for rows.Next() {
 		var answer investigation.BriefMessage
 		if err = rows.Scan(&answer.InvestigationID, &answer.CreatedAt, &answer.Text); err != nil {
-			return fmt.Errorf("scanning recent answer: %w", err)
+			return nil, fmt.Errorf("scanning recent answer: %w", err)
 		}
 		answer.Text = briefExchangeText(answer.Text)
-		brief.Recent = append(brief.Recent, answer)
+		answers = append(answers, answer)
 	}
 	if err = rows.Err(); err != nil {
-		return fmt.Errorf("reading recent answers: %w", err)
+		return nil, fmt.Errorf("reading recent answers: %w", err)
 	}
-	return nil
+	slices.Reverse(answers)
+	return answers, nil
 }
 
 func briefExchangeText(text string) string {

--- a/internal/store/postgres/conversation_brief.go
+++ b/internal/store/postgres/conversation_brief.go
@@ -69,7 +69,8 @@ func (p *Database) ConversationBrief(
 		}
 		exchange = append(exchange, message)
 	}
-	brief.Recent = append(exchange, answers...)
+	exchange = append(exchange, answers...)
+	brief.Recent = exchange
 	if len(brief.Recent) > tail {
 		brief.Recent = brief.Recent[len(brief.Recent)-tail:]
 	}

--- a/internal/store/postgres/conversation_exchange_test.go
+++ b/internal/store/postgres/conversation_exchange_test.go
@@ -77,3 +77,29 @@ func TestRecentAnswerMarksOptionalTextTruncation(t *testing.T) {
 		t.Fatalf("optional answer truncation was hidden: %+v", brief.Recent)
 	}
 }
+
+func TestRecentExchangePreservesMessageSequenceWhenTransactionTimesDisagree(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, organization := migratedDatabase(t)
+	opened := openConversation(t, database, organization, "concurrent correction")
+	say(t, database, organization, opened.ID, "production is affected")
+	say(t, database, organization, opened.ID, "correction: staging is affected")
+	pool, err := database.Pool(organization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = pool.Exec(ctx, `UPDATE conversation_message
+		SET created_at = '2026-09-06T10:00:00Z'::timestamptz - sequence * interval '1 second'
+		WHERE org_id = $1 AND conversation_id = $2`, organization.String(), opened.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	brief, err := database.ConversationBrief(ctx, organization, opened.ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(brief.Recent) != 2 || brief.Recent[0].Sequence != 1 || brief.Recent[1].Sequence != 2 {
+		t.Fatalf("transaction timestamps reversed a durable correction: %+v", brief.Recent)
+	}
+}

--- a/internal/store/postgres/conversation_exchange_test.go
+++ b/internal/store/postgres/conversation_exchange_test.go
@@ -1,0 +1,79 @@
+package storage_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestConversationBriefIncludesCanonicalAnswerBeforeCorrection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, organization := migratedDatabase(t)
+	opened := openConversation(t, database, organization, "recent exchange")
+	say(t, database, organization, opened.ID, "is production affected?")
+	turn, took, err := database.OpenTurn(ctx, organization, opened.ID, turnWindowLead)
+	if err != nil || !took {
+		t.Fatalf("opening turn: took=%v err=%v", took, err)
+	}
+	if err = database.ConcludeInvestigation(ctx, organization, turn.InvestigationID,
+		investigation.Conclusion{Summary: "production appears affected"}, "", investigation.Usage{}); err != nil {
+		t.Fatal(err)
+	}
+	say(t, database, organization, opened.ID, "correction: that was staging")
+	brief, err := database.ConversationBrief(ctx, organization, opened.ID, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"is production affected?", "production appears affected", "correction: that was staging"}
+	if len(brief.Recent) != len(want) {
+		t.Fatalf("recent exchange = %+v, want question, canonical answer, correction", brief.Recent)
+	}
+	for n, text := range want {
+		if brief.Recent[n].Text != text {
+			t.Fatalf("exchange[%d] = %q, want %q", n, brief.Recent[n].Text, text)
+		}
+	}
+	if brief.Recent[0].Sequence != 1 || brief.Recent[2].Sequence != 2 ||
+		brief.Recent[1].InvestigationID != turn.InvestigationID || brief.Recent[1].FromPerson ||
+		brief.Recent[1].CreatedAt.IsZero() {
+		t.Fatalf("exchange lost source identity: %+v", brief.Recent)
+	}
+	limited, err := database.ConversationBrief(ctx, organization, opened.ID, 2)
+	if err != nil || len(limited.Recent) != 2 || limited.Recent[0].Text != want[1] || limited.Recent[1].Text != want[2] {
+		t.Fatalf("bounded exchange = %+v, err=%v", limited.Recent, err)
+	}
+	detail, err := database.ConversationDetail(ctx, organization, opened.ID, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Messages) != 2 {
+		t.Fatalf("answer was duplicated into authored Messages: %+v", detail.Messages)
+	}
+}
+
+func TestRecentAnswerMarksOptionalTextTruncation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, organization := migratedDatabase(t)
+	opened := openConversation(t, database, organization, "bounded answer")
+	say(t, database, organization, opened.ID, "explain")
+	turn, took, err := database.OpenTurn(ctx, organization, opened.ID, turnWindowLead)
+	if err != nil || !took {
+		t.Fatalf("opening turn: took=%v err=%v", took, err)
+	}
+	if err = database.ConcludeInvestigation(ctx, organization, turn.InvestigationID,
+		investigation.Conclusion{Summary: strings.Repeat("界", 2000)}, "", investigation.Usage{}); err != nil {
+		t.Fatal(err)
+	}
+	brief, err := database.ConversationBrief(ctx, organization, opened.ID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(brief.Recent) != 1 || len([]rune(brief.Recent[0].Text)) > investigation.BriefMessageBound ||
+		!strings.HasSuffix(brief.Recent[0].Text, " [truncated]") {
+		t.Fatalf("optional answer truncation was hidden: %+v", brief.Recent)
+	}
+}


### PR DESCRIPTION
Follow-up context omitted completed answers from its recent exchange. Project the current Conversation's completed Investigation summaries alongside authored Messages, bounded to 12 combined entries, without duplicating answers in Message storage. Retain source identities and timestamps; mark optional text clipping explicitly.

Preserve durable Message sequence even when concurrent PostgreSQL transaction timestamps disagree. Merge canonical answers without globally sorting Messages, so a correction cannot move ahead of the Message it corrects. Answers remain private to their Conversation and metadata reaches the existing model prompt.

Part of #48 section21. Older-history retrieval/sampler retirement, evidenceRefs and refresh semantics remain separate work. Issue #48 remains open.

Validation: RED/GREEN PostgreSQL answer, clipping and timestamp-order regressions; combined bounds, source identity and no duplicated Messages; model-visible identity/order. Full race suites, architecture, lint/build, OpenAPI/docs, vulnerability/license checks passed. Standards and spec reviews have no remaining findings. Full make verify retains the known frontend Dockerfile COPY web/ packaging failure; Helm and backend image checks passed.
