### PR TITLE
fix: remove unbound automatic Integration reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Read the complete [alert-to-action architecture walkthrough](./ARCHITECTURE.md).
 - Users can belong to several Organizations; Organization Admins cannot replace an existing User's password or revoke their global sessions.
 - Local Users change their own password after reauthentication. Deployment operators can recover an existing local User through stdin; see [credential recovery](docs/security/overview.mdx).
 - Connected content and prior history remain untrusted data. Current assigned Messages express requests within the verified tool scope.
-- External tools are read-only and every call records an operator-visible purpose.
+- The model selects from eligible read-only tools; each call is validated and records an operator-visible purpose.
+- Workload and namespace names alone never trigger reads across Integrations.
 - Secrets are file-backed or sealed; credential-shaped fields are removed from logs, events, audit details, prompts, and
   API responses.
 - OpenCluster proposes production changes but exposes no execution endpoint.

--- a/docs/integrations/infrastructure/kubernetes.mdx
+++ b/docs/integrations/infrastructure/kubernetes.mdx
@@ -20,6 +20,9 @@ Integration's comma-separated namespace allow-list can narrow that access and ca
 it. OpenCluster requests only the bounded read operations supported by both this deployment
 and the connected Relay.
 
+The model chooses relevant reads from the available tools. An alert's namespace or workload
+name does not automatically trigger reads against every Kubernetes Integration.
+
 Do not grant create, update, patch, delete, or Kubernetes Secret-data access. Inventory
 synchronization records identifiers, image references, quantities, versions, and hashes; it
 does not copy ConfigMap data, Secret data, or environment values.

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -110,7 +110,6 @@ type orientation struct {
 	Trigger     *investigation.Trigger
 	Sources     []offeredSource
 	Inventory   []string
-	Preflight   []investigation.ToolRun
 	Brief       *investigation.Brief
 }
 
@@ -245,51 +244,6 @@ func (r *Agent) Run(
 			}
 			return err
 		}
-	}
-	for _, call := range preflightCalls(oriented) {
-		identity := callIdentityOf(call)
-		var run investigation.ToolRun
-		executedRead := false
-		switch {
-		case state.executedIdentities[identity] != 0:
-			run = suppressedRun(opened, call, len(state.runs)+1,
-				state.executedIdentities[identity])
-			r.announce(ctx, events, investigation.EventProgress, investigation.ProgressPayload(
-				"Skipped a repeat of "+offeredName(offered, call.Tool)+
-					"; the earlier read already answers it"))
-		case state.executed >= state.maxRuns:
-			run = droppedRun(opened,
-				investigation.ToolCall{Tool: call.Tool, Arguments: call.Arguments},
-				len(state.runs)+1, fmt.Sprintf(
-					"not executed: the investigation's read budget of %d was exhausted",
-					state.maxRuns))
-			r.announce(ctx, events, investigation.EventProgress, investigation.ProgressPayload(
-				"Did not run "+offeredName(offered, call.Tool)+"; the read budget is exhausted"))
-		default:
-			ordinal := len(state.runs) + 1
-			r.announceToolStarted(ctx, state, call, ordinal)
-			var executeErr error
-			run, executeErr = r.execute(ctx, opened, selections(offered),
-				state.credentials, origin,
-				investigation.ToolCall{Tool: call.Tool, Arguments: call.Arguments}, ordinal)
-			if executeErr != nil {
-				return failRun("preflight provenance could not be recorded", state.usage)
-			}
-			r.announce(ctx, events, investigation.EventToolCompleted,
-				investigation.ToolCompletedPayload(run))
-			r.RuntimeTelemetry.RanTool(run)
-			state.executed++
-			executedRead = true
-		}
-		run.Purpose = boundText(call.Purpose, eventTextBound)
-		run.HypothesisID = boundText(call.HypothesisID, eventTextBound)
-		if preflightErr := r.recordToolRun(ctx, state, run); preflightErr != nil {
-			return failRun("preflight provenance could not be recorded", state.usage)
-		}
-		if executedRead {
-			state.executedIdentities[identity] = run.Ordinal
-		}
-		oriented.Preflight = append(oriented.Preflight, run)
 	}
 	state.task = taskInstruction(oriented)
 	state.orientationText = renderOrientation(oriented)
@@ -579,65 +533,6 @@ func modelPrompt(r *Agent, state *runState, forced bool) Prompt {
 	return prompt
 }
 
-func preflightCalls(oriented orientation) []toolCall {
-	if oriented.Trigger == nil || oriented.Brief != nil {
-		return nil
-	}
-	labels := oriented.Trigger.Labels
-	namespace := labels["namespace"]
-	workloadKind := labels["workload_kind"]
-	workloadName := labels["workload_name"]
-	exactNamespace := exactKubernetesIdentifier(namespace)
-	exactWorkload := exactNamespace && exactKubernetesIdentifier(workloadName) &&
-		(workloadKind == "Deployment" || workloadKind == "StatefulSet" ||
-			workloadKind == "DaemonSet")
-
-	var runtime, events []toolCall
-	for _, source := range oriented.Sources {
-		if source.Integration.Type != integrations.TypeKubernetes {
-			continue
-		}
-		for _, tool := range source.Tools {
-			base := strings.SplitN(tool.Name, "__", 2)[0]
-			switch {
-			case base == "kubernetes.workload.runtime" && exactWorkload:
-				runtime = append(runtime, toolCall{
-					ID: "preflight-runtime-" + source.Integration.ID.String(), Tool: tool.Name,
-					Purpose: "establish the exact workload's current runtime state",
-					Arguments: map[string]any{"namespace": namespace,
-						"workloadKind": workloadKind, "workloadName": workloadName},
-				})
-			case base == "kubernetes.namespace.events" && exactNamespace:
-				events = append(events, toolCall{
-					ID: "preflight-events-" + source.Integration.ID.String(), Tool: tool.Name,
-					Purpose:   "read recent events in the exact alert namespace",
-					Arguments: map[string]any{"namespace": namespace},
-				})
-			}
-		}
-	}
-	return append(runtime, events...)
-}
-
-func exactKubernetesIdentifier(value string) bool {
-	if value == "" || len(value) > 253 || value != strings.ToLower(value) ||
-		value[0] < 'a' || value[0] > 'z' {
-		return false
-	}
-	last := value[len(value)-1]
-	if (last < 'a' || last > 'z') && (last < '0' || last > '9') {
-		return false
-	}
-	for _, character := range value {
-		if (character >= 'a' && character <= 'z') ||
-			(character >= '0' && character <= '9') || character == '-' || character == '.' {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
 func decodeHypothesisSnapshot(
 	arguments map[string]any, runs int,
 ) ([]investigation.HypothesisResult, error) {
@@ -896,9 +791,6 @@ func orientationTokens(oriented orientation) int {
 	total := EstimateTokens(oriented.Subject) + EstimateTokens(oriented.Question)
 	for _, identity := range oriented.Inventory {
 		total += EstimateTokens(identity)
-	}
-	for _, run := range oriented.Preflight {
-		total += runTokens(run)
 	}
 	for _, source := range oriented.Sources {
 		total += EstimateTokens(source.Integration.Name)

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -218,7 +218,7 @@ func TestRunRecordsToolEvidenceBeforeTheNextModelCall(t *testing.T) {
 	}
 }
 
-func TestRunKeepsPreflightAndModelReadsInOneOrdinalSequence(t *testing.T) {
+func TestModelChoosesReadsBeforeWorkloadLabelsCauseExternalAccess(t *testing.T) {
 	integrationID, incidentID := uuid.New(), uuid.New()
 	store := &records{
 		candidate: integrations.Integration{ID: integrationID, Type: integrations.TypeKubernetes, Name: "cluster"},
@@ -226,12 +226,16 @@ func TestRunKeepsPreflightAndModelReadsInOneOrdinalSequence(t *testing.T) {
 			"namespace": "payments", "workload_kind": "Deployment", "workload_name": "checkout-api",
 		}},
 	}
+	modelSelected := false
 	run := func(_ context.Context, request integrations.ToolRequest) (integrations.ToolResult, error) {
+		if !modelSelected {
+			t.Fatal("workload labels triggered an external read before model selection")
+		}
 		return integrations.ToolResult{Summary: request.Arguments["namespace"].(string)}, nil
 	}
 	tools := []integrations.Tool{
-		{Name: "kubernetes.workload.runtime", Description: "runtime", WhenToUse: "preflight", WhenNotToUse: "never", Permissions: "read", Output: "state", Run: run},
-		{Name: "kubernetes.namespace.events", Description: "events", WhenToUse: "preflight", WhenNotToUse: "never", Permissions: "read", Output: "events", Run: run},
+		{Name: "kubernetes.workload.runtime", Description: "runtime", WhenToUse: "runtime state", WhenNotToUse: "never", Permissions: "read", Output: "state", Run: run},
+		{Name: "kubernetes.namespace.events", Description: "events", WhenToUse: "recent events", WhenNotToUse: "never", Permissions: "read", Output: "events", Run: run},
 		{Name: "kubernetes.pod.logs", Description: "logs", WhenToUse: "diagnosis", WhenNotToUse: "never", Permissions: "read", Output: "logs", Run: run},
 	}
 	catalog, err := integrations.NewCatalog(integrations.Definition{
@@ -245,15 +249,22 @@ func TestRunKeepsPreflightAndModelReadsInOneOrdinalSequence(t *testing.T) {
 	}
 	model := &scriptedModel{next: func(call int, prompt Prompt) (Completion, error) {
 		if call == 1 {
-			if !strings.Contains(prompt.Content[len(prompt.Content)-1].Text, "payments") {
-				t.Fatal("preflight results were not included in the first Model prompt")
+			for _, expected := range []string{"kubernetes.workload.runtime", "kubernetes.namespace.events", "kubernetes.pod.logs"} {
+				found := false
+				for _, offered := range prompt.Tools {
+					found = found || offered.Name == expected
+				}
+				if !found {
+					t.Fatalf("eligible tool %q missing from model choice", expected)
+				}
 			}
+			modelSelected = true
 			return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{
 				ID: "logs", Name: "kubernetes.pod.logs", Arguments: json.RawMessage(`{"purpose":"read logs","input":{"namespace":"payments"}}`),
 			}}}, nil
 		}
 		return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{
-			ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, []int{1, 2, 3}),
+			ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, []int{1}),
 		}}}, nil
 	}}
 	agent := configuredTestAgent(t, store, model, catalog)
@@ -264,8 +275,8 @@ func TestRunKeepsPreflightAndModelReadsInOneOrdinalSequence(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if len(store.runs) != 3 {
-		t.Fatalf("runs=%d, want two preflight reads and one Model read", len(store.runs))
+	if len(store.runs) != 1 || store.runs[0].Tool != "kubernetes.pod.logs" {
+		t.Fatalf("runs=%+v, want only the model-selected read", store.runs)
 	}
 	for index, recorded := range store.runs {
 		if recorded.Ordinal != index+1 {

--- a/internal/investigation/agent/prompt.go
+++ b/internal/investigation/agent/prompt.go
@@ -312,14 +312,6 @@ func renderOrientation(orientation orientation) string {
 			out.WriteString("- " + line + "\n")
 		}
 	}
-	if len(orientation.Preflight) > 0 {
-		out.WriteString("\nSELECTIVE PREFLIGHT READS, ordinary Tool Runs available for citation:\n")
-		for _, run := range orientation.Preflight {
-			rendered := renderResult(toolFeedback{CallID: "preflight", Run: run})
-			out.WriteString(rendered.Content)
-		}
-	}
-
 	// The conversation last, so a follow-up reads the estate first and then what has
 	// already been said about it — the same order a person joining an incident would.
 	out.WriteString(renderBrief(orientation.Brief))


### PR DESCRIPTION
An alert's workload and namespace labels previously triggered runtime/event reads across every eligible Kubernetes Integration before the model ran. Those labels do not bind a target Integration. Remove that automatic path and its preflight-only state, rendering and accounting. The existing model loop still receives eligible tools and validates every selected call at execution.

Part of #48 section21(2,8). No new planner or routing layer. Issue #48 remains open.

Validation: RED/GREEN regression proves no external read precedes model selection, all eligible runtime/events/log tools remain offered, and only the selected read is recorded with its ordinary ordinal. Current main, including PR60, was merged without conflicts. The combined commit passed full race suites, scope/model regressions, architecture, lint/build, OpenAPI/docs, vulnerability and license checks. Standards/spec reviews and merge review have no remaining findings.

Full make verify still fails at the existing frontend Dockerfile COPY web/ release-packaging defect. Helm and backend image checks passed. This PR does not complete release validation or the remaining issue48 phases.
