### PR TITLE
fix: commit terminal outcomes and replay events atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Investigations use complete assigned Messages. Input that cannot fit produces `n
 with the unprocessed Message sequences instead of silently truncating the request.
 Follow-ups receive a bounded recent exchange of Messages and completed answers, with
 timestamps and source identities retained.
+Terminal outcomes and their replay events commit together; failed event writes cannot
+leave a completed result without its ending event.
 
 ## Quick start
 

--- a/docs/concepts/investigations-and-conversations.mdx
+++ b/docs/concepts/investigations-and-conversations.mdx
@@ -18,6 +18,9 @@ marked as truncated. This bounded context is not a complete memory of the Conver
 
 Completed and `needs_input` Investigations never resume. Send a new Message to create the next turn.
 
+Completed answers and their final activity event are saved together, so reconnecting sees
+the same outcome. Failed final writes do not report a completed answer.
+
 Messages sent during an active Investigation wait for its completion. An Organization can
 have up to 100 unassigned person Messages waiting across its Conversations, alongside the
 separate limit for waiting Investigations. When capacity is full, new Messages are refused;

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -149,15 +149,8 @@ func (r *Agent) Run(
 
 	startedAt := time.Now()
 	failRun := func(reason string, usage investigation.Usage) error {
-		safeReason, err := r.persistFailure(ctx, organization, opened.ID, reason, usage)
-		if err != nil {
-			return err
-		}
-		writeCtx, done := terminalWriteWindow(ctx)
-		defer done()
-		r.announce(writeCtx, events, investigation.EventFailed,
-			investigation.FailedPayload(safeReason))
-		return nil
+		_, err := r.persistFailure(ctx, organization, opened.ID, reason, usage)
+		return err
 	}
 
 	var origin *investigation.ConversationOrigin
@@ -387,8 +380,6 @@ func (r *Agent) Run(
 				done()
 				return fmt.Errorf("recording investigation conclusion: %w", err)
 			}
-			r.announce(writeCtx, events, investigation.EventConcluded,
-				investigation.ConcludedPayload(conclusion, stoppedBy))
 			r.Logger.Info("investigation concluded",
 				slog.String("investigation_id", opened.ID.String()),
 				slog.Int("turns", state.turns),

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -149,8 +149,7 @@ func (r *Agent) Run(
 
 	startedAt := time.Now()
 	failRun := func(reason string, usage investigation.Usage) error {
-		_, err := r.persistFailure(ctx, organization, opened.ID, reason, usage)
-		return err
+		return r.persistFailure(ctx, organization, opened.ID, reason, usage)
 	}
 
 	var origin *investigation.ConversationOrigin

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -68,6 +68,8 @@ func (r *records) ConcludeInvestigation(_ context.Context, _ tenancy.Organizatio
 		return r.terminalErr
 	}
 	r.conclusion, r.status, r.stoppedBy, r.usage = conclusion, investigation.StatusConcluded, stoppedBy, usage
+	r.events = append(r.events, investigation.Event{Sequence: int64(len(r.events) + 1), At: time.Now(),
+		Type: investigation.EventConcluded, Payload: investigation.ConcludedPayload(conclusion, stoppedBy)})
 	return nil
 }
 func (r *records) FailInvestigation(_ context.Context, _ tenancy.Organization, _ uuid.UUID, reason string, usage investigation.Usage) error {
@@ -77,6 +79,8 @@ func (r *records) FailInvestigation(_ context.Context, _ tenancy.Organization, _
 		return r.terminalErr
 	}
 	r.status, r.failure, r.usage = investigation.StatusFailed, reason, usage
+	r.events = append(r.events, investigation.Event{Sequence: int64(len(r.events) + 1), At: time.Now(),
+		Type: investigation.EventFailed, Payload: investigation.FailedPayload(reason)})
 	return nil
 }
 func (r *records) TriggerIncident(context.Context, tenancy.Organization, uuid.UUID) (investigation.Trigger, error) {

--- a/internal/investigation/agent/input.go
+++ b/internal/investigation/agent/input.go
@@ -38,6 +38,5 @@ func (r *Agent) requestNarrowerInput(ctx context.Context, state *runState, messa
 		investigation.StoppedByContext, state.usage); err != nil {
 		return fmt.Errorf("recording unprocessed input: %w", err)
 	}
-	r.announce(writeCtx, state.events, investigation.EventConcluded, investigation.ConcludedPayload(conclusion, investigation.StoppedByContext))
 	return nil
 }

--- a/internal/investigation/agent/tools.go
+++ b/internal/investigation/agent/tools.go
@@ -181,14 +181,14 @@ func (r *Agent) execute(
 func (r *Agent) persistFailure(
 	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
 	reason string, usage investigation.Usage,
-) (string, error) {
+) error {
 	writeCtx, done := terminalWriteWindow(ctx)
 	defer done()
 	reason = boundText(reason, maxRunErrorLength)
 	if err := r.Store.FailInvestigation(writeCtx, organization, id, reason, usage); err != nil {
-		return reason, fmt.Errorf("recording investigation failure: %w", err)
+		return fmt.Errorf("recording investigation failure: %w", err)
 	}
-	return reason, nil
+	return nil
 }
 
 // announce treats progress as best effort. Terminal events commit with the result.

--- a/internal/investigation/agent/tools.go
+++ b/internal/investigation/agent/tools.go
@@ -191,12 +191,7 @@ func (r *Agent) persistFailure(
 	return reason, nil
 }
 
-// announce writes one event and swallows the failure into a log line.
-//
-// An event that could not be written must not end an investigation. The record is the
-// investigation and its provenance; the stream is a view of it being produced, and trading
-// a completed diagnosis for a missing progress line would be the wrong way round. A write
-// that fails is visible as a gap in the sequence, which is what the log line explains.
+// announce treats progress as best effort. Terminal events commit with the result.
 func (r *Agent) announce(
 	ctx context.Context, events *investigation.EventStream, eventType investigation.EventType, payload map[string]any,
 ) {

--- a/internal/investigation/events.go
+++ b/internal/investigation/events.go
@@ -159,13 +159,17 @@ func (s *stream) emit(
 		s.mu.Unlock()
 		return nil
 	}
-	s.sequence++
 	event := Event{
-		Sequence: s.sequence,
+		Sequence: s.sequence + 1,
 		At:       time.Now().UTC(),
 		Type:     eventType,
 		Payload:  safePayload(payload),
 	}
+	if err := s.appendEvent(ctx, s.organization, s.investigation, event); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.sequence = event.Sequence
 	if eventType.Terminal() {
 		s.closed = true
 	}
@@ -178,7 +182,7 @@ func (s *stream) emit(
 	if firstEvent {
 		s.telemetry.firstEvent(time.Since(s.startedAt))
 	}
-	return s.appendEvent(ctx, s.organization, s.investigation, event)
+	return nil
 }
 
 // safePayload drops credential-shaped keys, mechanically, by the SAME rule the audit path

--- a/internal/store/postgres/investigation.go
+++ b/internal/store/postgres/investigation.go
@@ -260,7 +260,8 @@ func (p *Database) ConcludeInvestigation(
 		return fmt.Errorf("encoding conclusion: %w", err)
 	}
 	return p.endInvestigation(ctx, organization, id, int16(investigation.StatusConcluded),
-		encoded, stoppedBy, "", usage)
+		encoded, stoppedBy, "", usage, investigation.EventConcluded,
+		investigation.ConcludedPayload(conclusion, stoppedBy))
 }
 
 // FailInvestigation ends one with the reason it could not conclude.
@@ -269,7 +270,7 @@ func (p *Database) FailInvestigation(
 	reason string, usage investigation.Usage,
 ) error {
 	return p.endInvestigation(ctx, organization, id, int16(investigation.StatusFailed),
-		[]byte("{}"), "", reason, usage)
+		[]byte("{}"), "", reason, usage, investigation.EventFailed, investigation.FailedPayload(reason))
 }
 
 // CancelInvestigation ends active work and records the operator action atomically.
@@ -339,13 +340,22 @@ func (p *Database) CancelInvestigation(
 func (p *Database) endInvestigation(
 	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
 	status int16, conclusion []byte, stoppedBy, reason string,
-	usage investigation.Usage,
+	usage investigation.Usage, eventType investigation.EventType, payload map[string]any,
 ) error {
 	pool, err := p.Pool(organization)
 	if err != nil {
 		return err
 	}
-	tag, err := pool.Exec(ctx, `
+	encodedPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encoding terminal event: %w", err)
+	}
+	transaction, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning terminal transition: %w", err)
+	}
+	defer func() { _ = transaction.Rollback(ctx) }()
+	tag, err := transaction.Exec(ctx, `
 		UPDATE investigation
 		   SET status              = $3,
 		       conclusion          = $4,
@@ -368,7 +378,15 @@ func (p *Database) endInvestigation(
 	if tag.RowsAffected() == 0 {
 		return investigation.ErrUnknown
 	}
-	return nil
+	if _, err = transaction.Exec(ctx, `
+		INSERT INTO investigation_event (investigation_id, org_id, sequence, type, payload)
+		SELECT $1, $2, coalesce(max(sequence), 0) + 1, $3, $4
+		  FROM investigation_event
+		 WHERE investigation_id = $1 AND org_id = $2`,
+		id, organization.String(), int16(eventType), encodedPayload); err != nil {
+		return fmt.Errorf("recording terminal event: %w", err)
+	}
+	return transaction.Commit(ctx)
 }
 
 // triggerColumns joins an incident with its newest alert_event's labels, annotations and

--- a/internal/store/postgres/investigation_event.go
+++ b/internal/store/postgres/investigation_event.go
@@ -22,9 +22,7 @@ const maxEventPage = 500
 
 // AppendEvent writes one event at the sequence it carries.
 //
-// The parent-row lock serializes progress with cancellation across replicas. Concluded
-// and failed runs may still emit their final answer or terminal event after their durable
-// status changes, but a cancelled stream never accepts anything after its terminal event.
+// The parent-row lock serializes progress with terminal transitions across replicas.
 func (p *Database) AppendEvent(
 	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
 	event investigation.Event,
@@ -42,10 +40,10 @@ func (p *Database) AppendEvent(
 		                                 payload)
 		SELECT $1, $2, $3, $4, $5, $6
 		  FROM investigation
-		 WHERE investigation_id = $1 AND org_id = $2 AND status <> $7
+		 WHERE investigation_id = $1 AND org_id = $2 AND status = $7
 		 FOR NO KEY UPDATE`,
 		id, organization.String(), event.Sequence, event.At, int16(event.Type),
-		payload, int16(investigation.StatusCancelled))
+		payload, int16(investigation.StatusRunning))
 	if err != nil {
 		return fmt.Errorf("appending an investigation event: %w", err)
 	}

--- a/internal/store/postgres/investigation_stream_test.go
+++ b/internal/store/postgres/investigation_stream_test.go
@@ -1,0 +1,40 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestFailedEventWritePreservesStreamStateForRetry(t *testing.T) {
+	for _, eventType := range []investigation.EventType{investigation.EventProgress, investigation.EventFailed} {
+		t.Run(eventType.String(), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			database, org := migratedDatabase(t)
+			id := aTurn(t, database, org)
+			pool, err := database.Pool(org)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stream := investigation.NewEventStream(database.AppendEvent, nil, org, id)
+			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event ADD CONSTRAINT reject_stream_test CHECK (type NOT IN (2, 7))`); err != nil {
+				t.Fatal(err)
+			}
+			if err = stream.Emit(ctx, eventType, nil); err == nil {
+				t.Fatal("event write failure was swallowed")
+			}
+			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event DROP CONSTRAINT reject_stream_test`); err != nil {
+				t.Fatal(err)
+			}
+			if err = stream.Emit(ctx, eventType, nil); err != nil {
+				t.Fatal(err)
+			}
+			events, err := database.Events(ctx, org, id, 0, 0)
+			if err != nil || len(events) != 1 || events[0].Sequence != 1 || events[0].Type != eventType {
+				t.Fatalf("failed write consumed stream state: events=%+v err=%v", events, err)
+			}
+		})
+	}
+}

--- a/internal/store/postgres/investigation_terminal_test.go
+++ b/internal/store/postgres/investigation_terminal_test.go
@@ -1,0 +1,99 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestConclusionCommitsItsReplayEvent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	conversation := openConversation(t, database, org, "durable completion")
+	say(t, database, org, conversation.ID, "what happened?")
+	turn, took, err := database.OpenTurn(ctx, org, conversation.ID, turnWindowLead)
+	if err != nil || !took {
+		t.Fatalf("opening turn: took=%v err=%v", took, err)
+	}
+	if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID,
+		conclusionSaying("canonical answer"), "", investigation.Usage{}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := database.Events(ctx, org, turn.InvestigationID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Type != investigation.EventConcluded ||
+		events[0].Payload["summary"] != "canonical answer" {
+		t.Fatalf("completion returned without its replay event: %+v", events)
+	}
+}
+
+func TestTerminalEventFailureRollsBackOutcome(t *testing.T) {
+	for _, failure := range []bool{false, true} {
+		t.Run(map[bool]string{false: "concluded", true: "failed"}[failure], func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			database, org := migratedDatabase(t)
+			conversation := openConversation(t, database, org, "terminal rollback")
+			say(t, database, org, conversation.ID, "what happened?")
+			turn, took, err := database.OpenTurn(ctx, org, conversation.ID, turnWindowLead)
+			if err != nil || !took {
+				t.Fatalf("opening turn: took=%v err=%v", took, err)
+			}
+			pool, err := database.Pool(org)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event ADD CONSTRAINT reject_terminal_test CHECK (type NOT IN (6, 7))`); err != nil {
+				t.Fatal(err)
+			}
+			finish := func() error {
+				if failure {
+					return database.FailInvestigation(ctx, org, turn.InvestigationID, "provider unavailable", investigation.Usage{InputTokens: 42})
+				}
+				return database.ConcludeInvestigation(ctx, org, turn.InvestigationID, conclusionSaying("answer"), "", investigation.Usage{InputTokens: 42})
+			}
+			if err = finish(); err == nil {
+				t.Fatal("terminal event failure was swallowed")
+			}
+			found, err := database.Investigation(ctx, org, turn.InvestigationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if found.Status != investigation.StatusRunning || found.Usage.InputTokens != 0 || found.Conclusion.Summary != "" || !found.ConcludedAt.IsZero() {
+				t.Fatalf("terminal failure committed outcome: %+v", found)
+			}
+			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event DROP CONSTRAINT reject_terminal_test`); err != nil {
+				t.Fatal(err)
+			}
+			if err = finish(); err != nil {
+				t.Fatal(err)
+			}
+			events, err := database.Events(ctx, org, turn.InvestigationID, 0, 0)
+			if err != nil || len(events) != 1 || events[0].Sequence != 1 || !events[0].Type.Terminal() {
+				t.Fatalf("retry lost terminal event or sequence: %+v err=%v", events, err)
+			}
+		})
+	}
+}
+
+func TestLateProgressCannotFollowCompletion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	conversation := openConversation(t, database, org, "no late progress")
+	say(t, database, org, conversation.ID, "what happened?")
+	turn, took, err := database.OpenTurn(ctx, org, conversation.ID, turnWindowLead)
+	if err != nil || !took {
+		t.Fatalf("opening turn: took=%v err=%v", took, err)
+	}
+	if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID, conclusionSaying("done"), "", investigation.Usage{}); err != nil {
+		t.Fatal(err)
+	}
+	if err = database.AppendEvent(ctx, org, turn.InvestigationID, investigation.Event{Sequence: 2, Type: investigation.EventProgress}); err == nil {
+		t.Fatal("completed Investigation accepted late activity")
+	}
+}

--- a/test/controlplane/terminal_replay_test.go
+++ b/test/controlplane/terminal_replay_test.go
@@ -1,0 +1,57 @@
+package controlplane
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+)
+
+func TestCompletedInvestigationReplaysOneCanonicalEnding(t *testing.T) {
+	address := freeAddress(t)
+	running := startControlPlaneRunning(t, func(cfg *config.Config) {
+		cfg.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		cfg.OperatorTokenDigest = digest[:]
+		cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+	}, app.Options{Model: concludingModel{}})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	_, turn := plane.openConversation(t, "terminal replay", "what happened?")
+	final := plane.awaitInvestigation(t, turn)
+	var result struct {
+		Summary string `json:"summary"`
+	}
+	decodeInto(t, final, &result)
+	status, replay := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+turn+"/events", nil)
+	if status != http.StatusOK {
+		t.Fatalf("replay = %d: %s", status, replay)
+	}
+	endings := 0
+	for _, line := range strings.Split(replay, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event struct {
+			Type    string `json:"type"`
+			Payload struct {
+				Summary string `json:"summary"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Type == "concluded" {
+			endings++
+			if event.Payload.Summary != result.Summary {
+				t.Fatalf("replay summary=%q, result=%q", event.Payload.Summary, result.Summary)
+			}
+		}
+	}
+	if endings != 1 {
+		t.Fatalf("terminal events=%d, want one: %s", endings, replay)
+	}
+}


### PR DESCRIPTION
Ordinary completion previously saved the result before attempting a separate terminal event whose failure was only logged. Commit conclusion/failure state, canonical result, usage and replay event in one PostgreSQL transaction. Event insertion failure now rolls back the outcome and returns to the worker.

Remove duplicate terminal announcements from the Agent. Refuse progress after any terminal state. Advance local stream sequence and closure only after persistence succeeds, so a failed write remains retryable.

Part of #48 section4. Claim-unique worker fencing and database-owned progress sequences remain the next coordinated slice; this PR retains the existing duplicate-sequence backstop. SSE timeout/proxy behavior and the broader issue remain incomplete.

Validation: RED/GREEN PostgreSQL terminal replay, rollback and retry-state regressions; full application and E2E Go race suites; composed HTTP/SSE single canonical ending; model, architecture, lint, build, documentation and scan gates pass. Independent spec and standards reviews are clear. GitHub CI passes. Full make verify fails only at the known baseline frontend Dockerfile COPY of missing web/: backend image and Helm validation pass, frontend packaging and subsequent release routing proof remain blocked.
