### PR TITLE
Reject expired Investigation lease renewals

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Follow-ups receive a bounded recent exchange of Messages and completed answers, 
 timestamps and source identities retained.
 Terminal outcomes and their replay events commit together; failed event writes cannot
 leave a completed result without its ending event.
+Expired worker leases cannot be renewed; recovery ends the interrupted Investigation.
 
 ## Quick start
 

--- a/internal/store/postgres/investigation_lease.go
+++ b/internal/store/postgres/investigation_lease.go
@@ -51,12 +51,7 @@ func (p *Database) ClaimInvestigation(
 	return named, claimed, true, nil
 }
 
-// Heartbeat renews a lease this worker holds.
-//
-// The worker is part of the WHERE clause, so a lease that was swept and re-claimed by
-// somebody else cannot be renewed by the process that lost it. That is the fence: the
-// holder learns it is no longer the holder, from the database, rather than continuing to
-// write for an investigation another worker is now running.
+// Heartbeat renews only an unexpired lease held by this worker.
 func (p *Database) Heartbeat(
 	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
 	claim investigation.Claim,
@@ -71,7 +66,8 @@ func (p *Database) Heartbeat(
 		 WHERE investigation_id = $1
 		   AND org_id           = $2
 		   AND status           = 1
-		   AND lease_worker     = $3`,
+		   AND lease_worker     = $3
+		   AND lease_expires_at > now()`,
 		id, organization.String(), claim.Worker, claim.LeaseFor.String())
 	if err != nil {
 		return false, fmt.Errorf("renewing an investigation lease: %w", err)

--- a/internal/store/postgres/investigation_lease_expiry_test.go
+++ b/internal/store/postgres/investigation_lease_expiry_test.go
@@ -1,0 +1,35 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestExpiredLeaseCannotBeRenewedBeforeRecovery(t *testing.T) {
+	t.Parallel()
+	database, organization := migratedDatabase(t)
+	ctx := context.Background()
+	conversation := openConversation(t, database, organization, "checkout is slow")
+	say(t, database, organization, conversation.ID, "what changed?")
+	turn, took, err := database.OpenTurn(ctx, organization, conversation.ID, turnWindowLead)
+	if err != nil || !took {
+		t.Fatalf("opening turn: took=%v err=%v", took, err)
+	}
+	claim := aClaim("original-worker")
+	if _, _, took, err = database.ClaimInvestigation(ctx, claim); err != nil || !took {
+		t.Fatalf("claiming: took=%v err=%v", took, err)
+	}
+	expireInvestigationLease(t, database, organization, turn.InvestigationID)
+	if held, err := database.Heartbeat(ctx, organization, turn.InvestigationID, claim); err != nil || held {
+		t.Fatalf("expired lease renewed: held=%v err=%v", held, err)
+	}
+	if recovered, err := database.RecoverStale(ctx, investigation.RecoveryReason, 10); err != nil || recovered != 1 {
+		t.Fatalf("recovering expired lease: recovered=%d err=%v", recovered, err)
+	}
+	found, err := database.Investigation(ctx, organization, turn.InvestigationID)
+	if err != nil || found.Status != investigation.StatusFailed {
+		t.Fatalf("recovered status=%v err=%v", found.Status, err)
+	}
+}


### PR DESCRIPTION
An Investigation worker could renew its expired lease before the recovery sweep, extending ownership after it had lapsed. Heartbeat now requires an unexpired lease as well as the existing Organization, status and worker guards.

A real PostgreSQL regression first reproduced the renewal, then passed with the expiry guard and verified that stale recovery still ends the Investigation. Existing live-owner, other-worker and competing-claim regressions pass. Independent standards and spec reviews found no actionable defects.

Full make verify passed the PostgreSQL race suite, lint/build, documentation, scans, backend image and Helm gates. The composed suite had one Alertmanager resolved-delivery timeout; that exact test passed on an isolated race-enabled rerun. The separate E2E module race suite also passed. The existing frontend Dockerfile COPY of missing web/ also fails, so full local verification is not green. GitHub CI passed in 9m23s.

This is a bounded part of issue #48; claim-unique tokens, fencing every worker write, and database progress-sequence allocation remain unfinished. Issue #48 remains open.
