### PR TITLE
Paginate Conversation turns with scoped cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ timestamps and source identities retained.
 Terminal outcomes and their replay events commit together; failed event writes cannot
 leave a completed result without its ending event.
 Expired worker leases cannot be renewed; recovery ends the interrupted Investigation.
+Conversation detail includes the first 50 turns; use `turnsNext` with the turns endpoint
+to continue reading in order, with up to 200 turns per page.
 
 ## Quick start
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -793,6 +793,21 @@ paths:
       responses:
         "200": { $ref: "#/components/responses/ConversationDetail" }
         default: { $ref: "#/components/responses/ErrorResponse" }
+  /api/v1/conversations/{conversation}/turns:
+    parameters: *conversation-path
+    get:
+      <<: *privileged-read
+      operationId: listConversationTurns
+      summary: List conversation turns
+      description: Returns turns ordered by turn number then Investigation ID, ascending. Cursors are scoped to the Organization, Conversation and ordering. Only limit and cursor are accepted.
+      tags: [Conversations]
+      parameters:
+        - { $ref: "#/components/parameters/Organization" }
+        - { $ref: "#/components/parameters/Limit" }
+        - { $ref: "#/components/parameters/Cursor" }
+      responses:
+        "200": { description: A bounded page of turns., content: { application/json: { schema: { $ref: "#/components/schemas/ConversationTurnPage" } } } }
+        default: { $ref: "#/components/responses/ErrorResponse" }
   /api/v1/conversations/{conversation}/messages:
     parameters: *conversation-path
     post:
@@ -2070,14 +2085,22 @@ components:
       properties:
         <<: *page-metadata
         items: { type: array, items: { $ref: "#/components/schemas/Conversation" } }
+    ConversationTurnPage:
+      type: object
+      additionalProperties: false
+      required: [turns, next]
+      properties:
+        turns: { type: array, maxItems: 200, items: { $ref: "#/components/schemas/ConversationTurn" } }
+        next: { oneOf: [{ type: string, maxLength: 512 }, { type: "null" }] }
     ConversationDetail:
       allOf:
         - { $ref: "#/components/schemas/Conversation" }
         - type: object
-          required: [messages, turns]
+          required: [messages, turns, turnsNext]
           properties:
             messages: { type: array, items: { $ref: "#/components/schemas/ConversationMessage" } }
-            turns: { type: array, items: { $ref: "#/components/schemas/ConversationTurn" } }
+            turns: { type: array, maxItems: 50, description: First page ordered by turn number then Investigation ID ascending., items: { $ref: "#/components/schemas/ConversationTurn" } }
+            turnsNext: { description: Pass as cursor to the Conversation turns endpoint; null when exhausted., oneOf: [{ type: string, maxLength: 512 }, { type: "null" }] }
     ConversationOpened:
       allOf:
         - { $ref: "#/components/schemas/Conversation" }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1251,6 +1251,34 @@ paths:
       summary: Get conversation
       tags:
         - Conversations
+  /api/v1/conversations/{conversation}/turns:
+    parameters:
+      - $ref: '#/components/parameters/ConversationID'
+    get:
+      security:
+        - SessionCookie: []
+      x-opencluster-access: privileged
+      x-opencluster-organization-selector: required
+      x-opencluster-cookie-csrf: not-required
+      x-opencluster-idempotency: not-applicable
+      parameters:
+        - $ref: '#/components/parameters/Organization'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Cursor'
+      responses:
+        '200':
+          description: A bounded page of turns.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationTurnPage'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: listConversationTurns
+      summary: List conversation turns
+      description: Returns turns ordered by turn number then Investigation ID, ascending. Cursors are scoped to the Organization, Conversation and ordering. Only limit and cursor are accepted.
+      tags:
+        - Conversations
   /api/v1/conversations/{conversation}/messages:
     parameters:
       - $ref: '#/components/parameters/ConversationID'
@@ -4728,6 +4756,23 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Conversation'
+    ConversationTurnPage:
+      type: object
+      additionalProperties: false
+      required:
+        - turns
+        - next
+      properties:
+        turns:
+          type: array
+          maxItems: 200
+          items:
+            $ref: '#/components/schemas/ConversationTurn'
+        next:
+          oneOf:
+            - type: string
+              maxLength: 512
+            - type: 'null'
     ConversationDetail:
       allOf:
         - $ref: '#/components/schemas/Conversation'
@@ -4735,6 +4780,7 @@ components:
           required:
             - messages
             - turns
+            - turnsNext
           properties:
             messages:
               type: array
@@ -4742,8 +4788,16 @@ components:
                 $ref: '#/components/schemas/ConversationMessage'
             turns:
               type: array
+              maxItems: 50
+              description: First page ordered by turn number then Investigation ID ascending.
               items:
                 $ref: '#/components/schemas/ConversationTurn'
+            turnsNext:
+              description: Pass as cursor to the Conversation turns endpoint; null when exhausted.
+              oneOf:
+                - type: string
+                  maxLength: 512
+                - type: 'null'
     ConversationOpened:
       allOf:
         - $ref: '#/components/schemas/Conversation'

--- a/docs/concepts/investigations-and-conversations.mdx
+++ b/docs/concepts/investigations-and-conversations.mdx
@@ -18,6 +18,12 @@ marked as truncated. This bounded context is not a complete memory of the Conver
 
 Completed and `needs_input` Investigations never resume. Send a new Message to create the next turn.
 
+The Conversation API returns its first 50 turns, in ascending turn order. To read more,
+pass `turnsNext` as `cursor` to `GET /api/v1/conversations/{conversation}/turns`.
+That endpoint accepts `limit` from 1 to 200 (default 50) and returns `turns` and `next`.
+Continue until `next` is null. Cursors belong to the same Organization and Conversation;
+search and selectable sorting are not supported. The recent Message tail is separate.
+
 Completed answers and their final activity event are saved together, so reconnecting sees
 the same outcome. Failed final writes do not report a completed answer.
 

--- a/internal/conversation/handlers.go
+++ b/internal/conversation/handlers.go
@@ -54,6 +54,8 @@ func (h Handlers) Routes() authz.Table {
 			http.HandlerFunc(h.open)),
 		authz.Privileged(http.MethodGet, base+"/{conversation}", authz.ConversationRead,
 			http.HandlerFunc(h.read)),
+		authz.Privileged(http.MethodGet, base+"/{conversation}/turns", authz.ConversationRead,
+			http.HandlerFunc(h.turns)),
 		authz.Privileged(http.MethodPost, base+"/{conversation}/messages",
 			authz.ConversationWrite, http.HandlerFunc(h.say)),
 	}
@@ -275,8 +277,7 @@ func (h Handlers) list(writer http.ResponseWriter, request *http.Request) {
 	writeJSON(writer, http.StatusOK, listing.Answer(views, listed.Next, nil))
 }
 
-// read answers one conversation with its recent transcript and every turn it opened —
-// what a support engineer needs to explain what OpenCluster did, after the fact.
+// read answers one conversation with its recent transcript and first page of turns.
 func (h Handlers) read(writer http.ResponseWriter, request *http.Request) {
 	_, organization, id, ok := h.addressed(writer, request)
 	if !ok {

--- a/internal/conversation/record.go
+++ b/internal/conversation/record.go
@@ -216,6 +216,12 @@ type Detail struct {
 	Conversation Conversation
 	Messages     []Message
 	Turns        []Turn
+	TurnsNext    string
+}
+
+type TurnPage struct {
+	Turns []Turn
+	Next  string
 }
 
 type Store interface {
@@ -227,6 +233,8 @@ type Store interface {
 		org tenancy.Organization, page Page) (List, error)
 	ConversationDetail(ctx context.Context, org tenancy.Organization, id uuid.UUID,
 		messages int) (Detail, error)
+	ConversationTurns(ctx context.Context, org tenancy.Organization, id uuid.UUID,
+		limit int, cursor string) (TurnPage, error)
 	AppendMessageAndOpenTurn(
 		ctx context.Context,
 		who authz.Principal,

--- a/internal/conversation/turns.go
+++ b/internal/conversation/turns.go
@@ -3,6 +3,7 @@ package conversation
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/open-cluster/oc-control-plane/internal/api/listing"
 )
@@ -12,7 +13,12 @@ func (h Handlers) turns(writer http.ResponseWriter, request *http.Request) {
 	if !ok {
 		return
 	}
-	query, err := listing.Parse(request.URL.Query(), listing.Spec{})
+	values, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		writeJSON(writer, http.StatusBadRequest, errorView{Error: "query parameters are malformed"})
+		return
+	}
+	query, err := listing.Parse(values, listing.Spec{})
 	if err != nil {
 		writeJSON(writer, http.StatusBadRequest, errorView{Error: err.Error()})
 		return

--- a/internal/conversation/turns.go
+++ b/internal/conversation/turns.go
@@ -1,0 +1,37 @@
+package conversation
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/open-cluster/oc-control-plane/internal/api/listing"
+)
+
+func (h Handlers) turns(writer http.ResponseWriter, request *http.Request) {
+	_, organization, id, ok := h.addressed(writer, request)
+	if !ok {
+		return
+	}
+	query, err := listing.Parse(request.URL.Query(), listing.Spec{})
+	if err != nil {
+		writeJSON(writer, http.StatusBadRequest, errorView{Error: err.Error()})
+		return
+	}
+	ctx, cancel := context.WithTimeout(request.Context(), readTimeout)
+	defer cancel()
+	page, err := h.Store.ConversationTurns(ctx, organization, id, query.Limit, query.Cursor)
+	if err != nil {
+		h.fail(writer, request, err)
+		return
+	}
+	view := turnPageView{Turns: make([]turnView, 0, len(page.Turns)), Next: listing.Continuation(page.Next)}
+	for _, turn := range page.Turns {
+		view.Turns = append(view.Turns, turnViewOf(turn))
+	}
+	writeJSON(writer, http.StatusOK, view)
+}
+
+type turnPageView struct {
+	Turns []turnView `json:"turns"`
+	Next  *string    `json:"next"`
+}

--- a/internal/conversation/views.go
+++ b/internal/conversation/views.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/open-cluster/oc-control-plane/internal/api/listing"
 )
 
 type errorView struct {
@@ -53,8 +55,9 @@ type turnView struct {
 // detailView is one conversation with what was said in it and the turns it opened.
 type detailView struct {
 	conversationView
-	Messages []messageView `json:"messages"`
-	Turns    []turnView    `json:"turns"`
+	Messages  []messageView `json:"messages"`
+	Turns     []turnView    `json:"turns"`
+	TurnsNext *string       `json:"turnsNext"`
 }
 
 // messageAcceptedView is the answer to posting a message. It always reports the message
@@ -132,6 +135,7 @@ func detailViewOf(detail Detail) detailView {
 		conversationView: conversationViewOf(detail.Conversation),
 		Messages:         make([]messageView, 0, len(detail.Messages)),
 		Turns:            make([]turnView, 0, len(detail.Turns)),
+		TurnsNext:        listing.Continuation(detail.TurnsNext),
 	}
 	for _, message := range detail.Messages {
 		view.Messages = append(view.Messages, messageViewOf(message))

--- a/internal/store/postgres/conversation.go
+++ b/internal/store/postgres/conversation.go
@@ -187,41 +187,11 @@ func (p *Database) ConversationDetail(
 		return conversation.Detail{}, err
 	}
 
-	turnRows, err := pool.Query(ctx, `
-		SELECT investigation_id, turn, status, coalesce(conclusion->>'summary', ''),
-		       stopped_by, error, created_at,
-		       concluded_at
-		  FROM investigation
-		 WHERE org_id = $1 AND conversation_id = $2
-		 ORDER BY turn`, organization.String(), id)
+	turns, err := readConversationTurns(ctx, pool, organization, id, defaultPageSize, "")
 	if err != nil {
-		return conversation.Detail{}, fmt.Errorf("reading a conversation's turns: %w", err)
+		return conversation.Detail{}, err
 	}
-	defer turnRows.Close()
-
-	turns := make([]conversation.Turn, 0, 8)
-	for turnRows.Next() {
-		var (
-			turn        conversation.Turn
-			status      int16
-			concludedAt *time.Time
-		)
-		if err := turnRows.Scan(&turn.InvestigationID, &turn.Ordinal, &status,
-			&turn.Answer, &turn.StoppedBy, &turn.Error, &turn.CreatedAt,
-			&concludedAt); err != nil {
-			return conversation.Detail{}, fmt.Errorf("scanning a turn: %w", err)
-		}
-		turn.Status = investigationStatusWord(status)
-		if concludedAt != nil {
-			turn.ConcludedAt = *concludedAt
-		}
-		turns = append(turns, turn)
-	}
-	if err := turnRows.Err(); err != nil {
-		return conversation.Detail{}, fmt.Errorf("reading a conversation's turns: %w", err)
-	}
-
-	return conversation.Detail{Conversation: found, Messages: said, Turns: turns}, nil
+	return conversation.Detail{Conversation: found, Messages: said, Turns: turns.Turns, TurnsNext: turns.Next}, nil
 }
 
 // conversationMessages reads the newest bounded window of a conversation's transcript, in

--- a/internal/store/postgres/conversation_turn_page_test.go
+++ b/internal/store/postgres/conversation_turn_page_test.go
@@ -1,0 +1,60 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/conversation"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestConversationDetailBoundsTurns(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org, otherOrg := twoOrganizationsInOneDatabase(t)
+	opened := openConversation(t, database, org, "long conversation")
+	for range 201 {
+		say(t, database, org, opened.ID, "continue")
+		turn, took, err := database.OpenTurn(ctx, org, opened.ID, turnWindowLead)
+		if err != nil || !took {
+			t.Fatalf("opening turn: took=%v err=%v", took, err)
+		}
+		if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID,
+			conclusionSaying("answer"), "", investigation.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	detail, err := database.ConversationDetail(ctx, org, opened.ID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Turns) != 50 || detail.Turns[0].Ordinal != 1 || detail.Turns[49].Ordinal != 50 {
+		t.Fatalf("detail returned %d turns; want first 50 in ascending order", len(detail.Turns))
+	}
+	if detail.TurnsNext == "" {
+		t.Fatal("bounded detail omitted its continuation")
+	}
+	page, err := database.ConversationTurns(ctx, org, opened.ID, 0, detail.TurnsNext)
+	if err != nil || len(page.Turns) != 50 || page.Turns[0].Ordinal != 51 {
+		t.Fatalf("detail continuation = %+v err=%v", page, err)
+	}
+	page, err = database.ConversationTurns(ctx, org, opened.ID, 999, "")
+	if err != nil || len(page.Turns) != 200 || page.Next == "" {
+		t.Fatalf("maximum page returned %d turns, next=%q err=%v", len(page.Turns), page.Next, err)
+	}
+	page, err = database.ConversationTurns(ctx, org, opened.ID, 200, page.Next)
+	if err != nil || len(page.Turns) != 1 || page.Turns[0].Ordinal != 201 || page.Next != "" {
+		t.Fatalf("last page = %+v err=%v", page, err)
+	}
+	other := openConversation(t, database, otherOrg, "another organization")
+	if _, err = database.ConversationTurns(ctx, otherOrg, other.ID, 50, detail.TurnsNext); !errors.Is(err, conversation.ErrBadCursor) {
+		t.Fatalf("cursor reused across Organizations: %v", err)
+	}
+	for _, id := range []uuid.UUID{opened.ID, uuid.New()} {
+		if _, err = database.ConversationTurns(ctx, otherOrg, id, 50, ""); !errors.Is(err, conversation.ErrUnknown) {
+			t.Fatalf("foreign or missing Conversation: %v", err)
+		}
+	}
+}

--- a/internal/store/postgres/conversation_turns.go
+++ b/internal/store/postgres/conversation_turns.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/conversation"
+)
+
+func (p *Database) ConversationTurns(
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, limit int, cursor string,
+) (conversation.TurnPage, error) {
+	if _, err := p.Conversation(ctx, organization, id); err != nil {
+		return conversation.TurnPage{}, err
+	}
+	pool, err := p.Pool(organization)
+	if err != nil {
+		return conversation.TurnPage{}, err
+	}
+	return readConversationTurns(ctx, pool, organization, id, limit, cursor)
+}
+
+func readConversationTurns(
+	ctx context.Context, queries querier, organization tenancy.Organization, id uuid.UUID, limit int, cursor string,
+) (conversation.TurnPage, error) {
+	scope := "conversation-turns/" + organization.String() + "/" + id.String() + "/turn,investigationId"
+	value, afterID, err := decodeSortCursor(cursor, scope)
+	if err != nil {
+		return conversation.TurnPage{}, conversation.ErrBadCursor
+	}
+	var after int64
+	if afterID != nil {
+		after, err = strconv.ParseInt(value, 10, 32)
+		if err != nil || after < 1 || *afterID == uuid.Nil {
+			return conversation.TurnPage{}, conversation.ErrBadCursor
+		}
+	}
+	limit = pageLimit(limit)
+	rows, err := queries.Query(ctx, `
+		SELECT investigation_id, turn, status, coalesce(conclusion->>'summary', ''),
+		       stopped_by, error, created_at, concluded_at
+		  FROM investigation
+		 WHERE org_id = $1 AND conversation_id = $2
+		   AND ($3::integer = 0 OR (turn, investigation_id) > ($3, $4::uuid))
+		 ORDER BY turn, investigation_id
+		 LIMIT $5`, organization.String(), id, after, afterID, limit+1)
+	if err != nil {
+		return conversation.TurnPage{}, fmt.Errorf("reading conversation turns: %w", err)
+	}
+	defer rows.Close()
+	page := conversation.TurnPage{Turns: make([]conversation.Turn, 0, limit)}
+	for rows.Next() {
+		var turn conversation.Turn
+		var status int16
+		var concludedAt *time.Time
+		if err := rows.Scan(&turn.InvestigationID, &turn.Ordinal, &status, &turn.Answer,
+			&turn.StoppedBy, &turn.Error, &turn.CreatedAt, &concludedAt); err != nil {
+			return conversation.TurnPage{}, fmt.Errorf("scanning conversation turn: %w", err)
+		}
+		turn.Status = investigationStatusWord(status)
+		if concludedAt != nil {
+			turn.ConcludedAt = *concludedAt
+		}
+		page.Turns = append(page.Turns, turn)
+	}
+	if err := rows.Err(); err != nil {
+		return conversation.TurnPage{}, fmt.Errorf("reading conversation turns: %w", err)
+	}
+	if len(page.Turns) > limit {
+		page.Turns = page.Turns[:limit]
+		last := page.Turns[limit-1]
+		page.Next = encodeSortCursor(scope, strconv.Itoa(last.Ordinal), last.InvestigationID)
+	}
+	return page, nil
+}

--- a/test/architecture/openapi_test.go
+++ b/test/architecture/openapi_test.go
@@ -251,6 +251,7 @@ func TestOpenAPIListOperationsDeclareTheirQueryCapabilities(t *testing.T) {
 		"listIncidentAlertEvents":   paged,
 		"listInvestigations":        append(slices.Clone(paged), "InvestigationIncidentFilter"),
 		"listConversations":         append(slices.Clone(paged), "ConversationSearch", "ConversationSort", "ConversationIncidentFilter", "ConversationStateFilter"),
+		"listConversationTurns":     paged,
 		"listWebhookDeliveries":     append(slices.Clone(paged), "WebhookDeliveryStatus"),
 	}
 

--- a/test/architecture/permission_table_test.go
+++ b/test/architecture/permission_table_test.go
@@ -217,6 +217,7 @@ func TestThePR2RouteCutoverHasOneCanonicalShape(t *testing.T) {
 		"GET /api/v1/auth/oidc/start",
 		"GET /api/v1/conversations",
 		"GET /api/v1/conversations/{conversation}",
+		"GET /api/v1/conversations/{conversation}/turns",
 		"GET /api/v1/incidents",
 		"GET /api/v1/incidents/{incident}",
 		"GET /api/v1/incidents/{incident}/alert-events",

--- a/test/controlplane/conversation_turns_test.go
+++ b/test/controlplane/conversation_turns_test.go
@@ -56,7 +56,7 @@ func TestConversationTurnsPaginateAndRejectInvalidQueries(t *testing.T) {
 	if len(page.Turns) != 1 || page.Turns[0].InvestigationID != accepted.Turn.InvestigationID || page.Turns[0].Turn != 2 || page.Next != nil {
 		t.Fatalf("last page = %s", body)
 	}
-	for _, query := range []string{"limit=0", "limit=201", "limit=", "limit=1&limit=2", "cursor=", "cursor=bad", "cursor=a&cursor=b", "search=answer", "sort=turn", "unknown=value"} {
+	for _, query := range []string{"limit=0", "limit=201", "limit=", "limit=1&limit=2", "cursor=", "cursor=bad", "cursor=a&cursor=b", "search=answer", "sort=turn", "unknown=value", "cursor=%zz", "limit=1;sort=turn"} {
 		if status, body := plane.call(t, http.MethodGet, path+"/turns?"+query, nil); status != http.StatusBadRequest {
 			t.Errorf("query %s = %d: %s", query, status, body)
 		}

--- a/test/controlplane/conversation_turns_test.go
+++ b/test/controlplane/conversation_turns_test.go
@@ -1,0 +1,83 @@
+package controlplane
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+)
+
+func TestConversationTurnsPaginateAndRejectInvalidQueries(t *testing.T) {
+	address := freeAddress(t)
+	running := startControlPlaneRunning(t, func(cfg *config.Config) {
+		cfg.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		cfg.OperatorTokenDigest = digest[:]
+		cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+	}, app.Options{Model: concludingModel{}})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	id, first := plane.openConversation(t, "paginated conversation", "first question")
+	plane.awaitInvestigation(t, first)
+	path := plane.base(surfaceOrg) + "/conversations/" + id
+	status, body := plane.call(t, http.MethodPost, path+"/messages", map[string]any{"message": "second question"})
+	if status != http.StatusAccepted {
+		t.Fatalf("follow-up = %d: %s", status, body)
+	}
+	var accepted struct {
+		Turn struct{ InvestigationID string } `json:"turn"`
+	}
+	decodeInto(t, body, &accepted)
+	plane.awaitInvestigation(t, accepted.Turn.InvestigationID)
+	status, body = plane.call(t, http.MethodGet, path+"/turns?limit=1", nil)
+	if status != http.StatusOK {
+		t.Fatalf("first page = %d: %s", status, body)
+	}
+	var page struct {
+		Turns []struct {
+			InvestigationID string `json:"investigationId"`
+			Turn            int    `json:"turn"`
+		} `json:"turns"`
+		Next *string `json:"next"`
+	}
+	decodeInto(t, body, &page)
+	if len(page.Turns) != 1 || page.Turns[0].InvestigationID != first || page.Turns[0].Turn != 1 || page.Next == nil {
+		t.Fatalf("first page = %s", body)
+	}
+	cursor := url.QueryEscape(*page.Next)
+	status, body = plane.call(t, http.MethodGet, path+"/turns?limit=1&cursor="+cursor, nil)
+	if status != http.StatusOK {
+		t.Fatalf("next page = %d: %s", status, body)
+	}
+	decodeInto(t, body, &page)
+	if len(page.Turns) != 1 || page.Turns[0].InvestigationID != accepted.Turn.InvestigationID || page.Turns[0].Turn != 2 || page.Next != nil {
+		t.Fatalf("last page = %s", body)
+	}
+	for _, query := range []string{"limit=0", "limit=201", "limit=", "limit=1&limit=2", "cursor=", "cursor=bad", "cursor=a&cursor=b", "search=answer", "sort=turn", "unknown=value"} {
+		if status, body := plane.call(t, http.MethodGet, path+"/turns?"+query, nil); status != http.StatusBadRequest {
+			t.Errorf("query %s = %d: %s", query, status, body)
+		}
+	}
+	other, _ := plane.openConversation(t, "another conversation", "")
+	if status, body := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/conversations/"+other+"/turns?cursor="+cursor, nil); status != http.StatusBadRequest {
+		t.Errorf("cursor reused across conversations = %d: %s", status, body)
+	}
+	for _, suffix := range []string{"", "/turns?limit=200"} {
+		status, body := plane.call(t, http.MethodGet, path+suffix, nil)
+		if status != http.StatusOK {
+			t.Fatalf("reading %s = %d: %s", suffix, status, body)
+		}
+		var fields map[string]json.RawMessage
+		decodeInto(t, body, &fields)
+		field := "next"
+		if suffix == "" {
+			field = "turnsNext"
+		}
+		if string(fields[field]) != "null" {
+			t.Errorf("exhausted %s must be present and null: %s", field, body)
+		}
+	}
+}


### PR DESCRIPTION
Conversation detail previously returned every Investigation turn without a bound. It now returns the first 50 turns and nullable turnsNext. GET /api/v1/conversations/{conversation}/turns continues the same ascending (turn, investigationId) order with limit 1–200 (default 50), turns and nullable next.

The existing Conversation-read permission and explicit Organization selector protect the endpoint. Cursors bind Organization, Conversation and ordering. Existing listing validation rejects unsupported, duplicate, blank and malformed query parameters. Message-tail behavior is unchanged. OpenAPI, generated API documentation and usage documentation describe the changed completeness contract.

Validation: PostgreSQL RED/GREEN reproduced the unbounded detail, then verified default/max pages, continuation, and cross-Organization refusal. Composed HTTP RED/GREEN verifies the new route, continuation, invalid queries, cross-Conversation cursor rejection and explicit null cursors. The final correction also rejects malformed percent encoding and query separators instead of silently returning a default page; focused race, architecture, lint and vet checks pass on that commit. Both independent reviews are clear. Full PostgreSQL, composed-process and E2E race suites passed during local verification, along with builds, documentation and scans. Full make verify failed only at the existing frontend Dockerfile COPY of missing web/.

Final-head GitHub CI passed in 9m22s; documentation validation passed. Both independent reviews include the final query-parsing correction.

Part of issue #48 section 17. Worker fencing, explicit Message windows and other remaining issue work are separate; issue #48 remains incomplete. Known baseline release blocker: the frontend Dockerfile copies missing web/.
