### PR TITLE
Fence Investigation writes and serialize event sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ timestamps and source identities retained.
 Terminal outcomes and their replay events commit together; failed event writes cannot
 leave a completed result without its ending event.
 Expired worker leases cannot be renewed; recovery ends the interrupted Investigation.
+Each claim has a unique token fencing progress, Tool Runs and terminal writes. PostgreSQL
+allocates replay sequences under the same Investigation lock used by terminal transitions.
+Stop old control-plane replicas before upgrading to claim-token fencing; interrupted
+Investigations are recovered as failed rather than resumed by an older worker.
 Conversation detail includes the first 50 turns; use `turnsNext` with the turns endpoint
 to continue reading in order, with up to 200 turns per page.
 

--- a/docs/concepts/investigations-and-conversations.mdx
+++ b/docs/concepts/investigations-and-conversations.mdx
@@ -26,6 +26,7 @@ search and selectable sorting are not supported. The recent Message tail is sepa
 
 Completed answers and their final activity event are saved together, so reconnecting sees
 the same outcome. Failed final writes do not report a completed answer.
+An interrupted or superseded worker cannot append results or activity after losing ownership.
 
 Messages sent during an active Investigation wait for its completion. An Organization can
 have up to 100 unassigned person Messages waiting across its Conversations, alongside the

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -27,12 +27,12 @@ type Store interface {
 	ConversationOrigin(context.Context, tenancy.Organization, uuid.UUID) (*investigation.ConversationOrigin, error)
 	InvestigationMessages(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID) ([]investigation.AssignedMessage, error)
 	WorkloadInventory(context.Context, tenancy.Organization, int) ([]string, error)
-	RecordToolRun(context.Context, tenancy.Organization, uuid.UUID, investigation.ToolRun) error
+	RecordToolRun(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID, investigation.ToolRun) error
 	RecordCredentialUnseal(context.Context, tenancy.Organization, uuid.UUID, string) error
-	AppendEvent(context.Context, tenancy.Organization, uuid.UUID, investigation.Event) error
-	ConcludeInvestigation(context.Context, tenancy.Organization, uuid.UUID,
+	AppendEvent(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID, investigation.Event) error
+	ConcludeInvestigation(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID,
 		investigation.Conclusion, string, investigation.Usage) error
-	FailInvestigation(context.Context, tenancy.Organization, uuid.UUID, string, investigation.Usage) error
+	FailInvestigation(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID, string, investigation.Usage) error
 }
 
 // Agent runs investigations against one validated model deployment.
@@ -145,11 +145,13 @@ func (r *Agent) Run(
 ) error {
 
 	events := investigation.NewEventStream(
-		r.Store.AppendEvent, r.RuntimeTelemetry, organization, opened.ID)
+		func(ctx context.Context, org tenancy.Organization, id uuid.UUID, event investigation.Event) error {
+			return r.Store.AppendEvent(ctx, org, id, opened.ClaimToken, event)
+		}, r.RuntimeTelemetry, organization, opened.ID)
 
 	startedAt := time.Now()
 	failRun := func(reason string, usage investigation.Usage) error {
-		return r.persistFailure(ctx, organization, opened.ID, reason, usage)
+		return r.persistFailure(ctx, organization, opened.ID, opened.ClaimToken, reason, usage)
 	}
 
 	var origin *investigation.ConversationOrigin
@@ -374,7 +376,7 @@ func (r *Agent) Run(
 			conclusion.Actions = boundActions(conclusion.Actions)
 
 			writeCtx, done := terminalWriteWindow(ctx)
-			if err := r.Store.ConcludeInvestigation(writeCtx, organization, opened.ID,
+			if err := r.Store.ConcludeInvestigation(writeCtx, organization, opened.ID, opened.ClaimToken,
 				conclusion, stoppedBy, state.usage); err != nil {
 				done()
 				return fmt.Errorf("recording investigation conclusion: %w", err)
@@ -629,7 +631,7 @@ func (r *Agent) recordToolRun(
 		state.highestOrdinal = run.Ordinal
 	}
 	if err := r.Store.RecordToolRun(
-		ctx, state.organization, state.opened.ID, run); err != nil {
+		ctx, state.organization, state.opened.ID, state.opened.ClaimToken, run); err != nil {
 		return errProvenance
 	}
 	return nil

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -55,13 +55,13 @@ type records struct {
 	usage       investigation.Usage
 }
 
-func (r *records) RecordToolRun(_ context.Context, _ tenancy.Organization, _ uuid.UUID, run investigation.ToolRun) error {
+func (r *records) RecordToolRun(_ context.Context, _ tenancy.Organization, _ uuid.UUID, _ uuid.UUID, run investigation.ToolRun) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.runs = append(r.runs, run)
 	return nil
 }
-func (r *records) ConcludeInvestigation(_ context.Context, _ tenancy.Organization, _ uuid.UUID, conclusion investigation.Conclusion, stoppedBy string, usage investigation.Usage) error {
+func (r *records) ConcludeInvestigation(_ context.Context, _ tenancy.Organization, _ uuid.UUID, _ uuid.UUID, conclusion investigation.Conclusion, stoppedBy string, usage investigation.Usage) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.terminalErr != nil {
@@ -72,7 +72,7 @@ func (r *records) ConcludeInvestigation(_ context.Context, _ tenancy.Organizatio
 		Type: investigation.EventConcluded, Payload: investigation.ConcludedPayload(conclusion, stoppedBy)})
 	return nil
 }
-func (r *records) FailInvestigation(_ context.Context, _ tenancy.Organization, _ uuid.UUID, reason string, usage investigation.Usage) error {
+func (r *records) FailInvestigation(_ context.Context, _ tenancy.Organization, _ uuid.UUID, _ uuid.UUID, reason string, usage investigation.Usage) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.terminalErr != nil {
@@ -113,7 +113,7 @@ func (r *records) InvestigationMessages(context.Context, tenancy.Organization, u
 	return r.messages, r.messagesErr
 }
 func (r *records) AppendEvent(
-	_ context.Context, _ tenancy.Organization, _ uuid.UUID, event investigation.Event,
+	_ context.Context, _ tenancy.Organization, _ uuid.UUID, _ uuid.UUID, event investigation.Event,
 ) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/investigation/agent/input.go
+++ b/internal/investigation/agent/input.go
@@ -34,7 +34,7 @@ func (r *Agent) requestNarrowerInput(ctx context.Context, state *runState, messa
 	}
 	writeCtx, done := terminalWriteWindow(ctx)
 	defer done()
-	if err := r.Store.ConcludeInvestigation(writeCtx, state.organization, state.opened.ID, conclusion,
+	if err := r.Store.ConcludeInvestigation(writeCtx, state.organization, state.opened.ID, state.opened.ClaimToken, conclusion,
 		investigation.StoppedByContext, state.usage); err != nil {
 		return fmt.Errorf("recording unprocessed input: %w", err)
 	}

--- a/internal/investigation/agent/tools.go
+++ b/internal/investigation/agent/tools.go
@@ -179,13 +179,13 @@ func (r *Agent) execute(
 // persistFailure writes one terminal failure inside a detached window so cancellation
 // cannot erase the reason the run stopped.
 func (r *Agent) persistFailure(
-	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	reason string, usage investigation.Usage,
 ) error {
 	writeCtx, done := terminalWriteWindow(ctx)
 	defer done()
 	reason = boundText(reason, maxRunErrorLength)
-	if err := r.Store.FailInvestigation(writeCtx, organization, id, reason, usage); err != nil {
+	if err := r.Store.FailInvestigation(writeCtx, organization, id, token, reason, usage); err != nil {
 		return fmt.Errorf("recording investigation failure: %w", err)
 	}
 	return nil

--- a/internal/investigation/investigation.go
+++ b/internal/investigation/investigation.go
@@ -144,6 +144,7 @@ type Investigation struct {
 	WindowUntil    time.Time
 	Status         Status
 	Executing      bool
+	ClaimToken     uuid.UUID `json:"-"`
 	Conclusion     Conclusion
 	StoppedBy      string
 	Error          string

--- a/internal/investigation/runner.go
+++ b/internal/investigation/runner.go
@@ -102,7 +102,9 @@ func (r *Runner) runClaimed(
 	watchDone := make(chan struct{})
 	go func() {
 		defer close(watchDone)
-		r.watch(runCtx, stop, done, organization, opened.ID)
+		claim := r.claim()
+		claim.Token = opened.ClaimToken
+		r.watch(runCtx, stop, done, organization, opened.ID, claim)
 	}()
 
 	err := r.Agent.Run(runCtx, organization, opened)
@@ -124,7 +126,7 @@ func (r *Runner) runClaimed(
 
 func (r *Runner) watch(
 	ctx context.Context, stop context.CancelFunc, done <-chan struct{},
-	organization tenancy.Organization, id uuid.UUID,
+	organization tenancy.Organization, id uuid.UUID, claim Claim,
 ) {
 	renew := time.NewTicker(heartbeatInterval)
 	cancelled := time.NewTicker(time.Second)
@@ -143,7 +145,7 @@ func (r *Runner) watch(
 				return
 			}
 		case <-renew.C:
-			held, err := r.Store.Heartbeat(ctx, organization, id, r.claim())
+			held, err := r.Store.Heartbeat(ctx, organization, id, claim)
 			if err != nil {
 				r.logError(ctx, "an investigation lease could not be renewed", err)
 				continue
@@ -268,4 +270,5 @@ const RecoveryReason = "worker interrupted"
 type Claim struct {
 	Worker   string
 	LeaseFor time.Duration
+	Token    uuid.UUID
 }

--- a/internal/store/postgres/conversation_exchange_test.go
+++ b/internal/store/postgres/conversation_exchange_test.go
@@ -19,7 +19,7 @@ func TestConversationBriefIncludesCanonicalAnswerBeforeCorrection(t *testing.T) 
 		t.Fatalf("opening turn: took=%v err=%v", took, err)
 	}
 	if err = database.ConcludeInvestigation(ctx, organization, turn.InvestigationID,
-		investigation.Conclusion{Summary: "production appears affected"}, "", investigation.Usage{}); err != nil {
+		claimToken(t, database, organization, turn.InvestigationID), investigation.Conclusion{Summary: "production appears affected"}, "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	say(t, database, organization, opened.ID, "correction: that was staging")
@@ -65,7 +65,7 @@ func TestRecentAnswerMarksOptionalTextTruncation(t *testing.T) {
 		t.Fatalf("opening turn: took=%v err=%v", took, err)
 	}
 	if err = database.ConcludeInvestigation(ctx, organization, turn.InvestigationID,
-		investigation.Conclusion{Summary: strings.Repeat("界", 2000)}, "", investigation.Usage{}); err != nil {
+		claimToken(t, database, organization, turn.InvestigationID), investigation.Conclusion{Summary: strings.Repeat("界", 2000)}, "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	brief, err := database.ConversationBrief(ctx, organization, opened.ID, 1)

--- a/internal/store/postgres/conversation_queue_test.go
+++ b/internal/store/postgres/conversation_queue_test.go
@@ -32,7 +32,7 @@ func TestAtomicAppendQueuesWhileTurnIsActive(t *testing.T) {
 		t.Fatalf("follow-up = %+v", queued)
 	}
 	if err := database.ConcludeInvestigation(ctx, org, first.InvestigationID,
-		conclusionSaying("first answer"), "", investigation.Usage{}); err != nil {
+		claimToken(t, database, org, first.InvestigationID), conclusionSaying("first answer"), "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	second, started, err := database.OpenTurn(ctx, org, opened.ID, turnWindowLead)
@@ -82,7 +82,7 @@ func TestCompetingAtomicAppendsDrainExactlyOnce(t *testing.T) {
 		}
 	}
 	if err := database.ConcludeInvestigation(ctx, org, first.InvestigationID,
-		conclusionSaying("first answer"), "", investigation.Usage{}); err != nil {
+		claimToken(t, database, org, first.InvestigationID), conclusionSaying("first answer"), "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	type drainResult struct {
@@ -282,7 +282,7 @@ func TestLegacyMessageBacklogDrainsInBoundedOrderedBatches(t *testing.T) {
 			t.Fatalf("batch attributed to %q, want actor-%d", actor, last)
 		}
 		if err := database.ConcludeInvestigation(ctx, org, turn.InvestigationID,
-			conclusionSaying("answer"), "", investigation.Usage{}); err != nil {
+			claimToken(t, database, org, turn.InvestigationID), conclusionSaying("answer"), "", investigation.Usage{}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/store/postgres/conversation_test.go
+++ b/internal/store/postgres/conversation_test.go
@@ -235,7 +235,7 @@ func TestQueuedMessagesDrainIntoOneNextTurn(t *testing.T) {
 	}
 
 	if err = database.ConcludeInvestigation(context.Background(), organization,
-		first.InvestigationID, conclusionSaying("nothing changed"), "",
+		first.InvestigationID, claimToken(t, database, organization, first.InvestigationID), conclusionSaying("nothing changed"), "",
 		investigation.Usage{}); err != nil {
 		t.Fatalf("concluding the first turn: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestConversationsOnOneIncidentShareFindingsAndNothingElse(t *testing.T) {
 		t.Fatalf("opening Ada's turn: took=%v err=%v", took, err)
 	}
 	if err = database.RecordToolRun(context.Background(), organization,
-		adaTurn.InvestigationID, investigation.ToolRun{
+		adaTurn.InvestigationID, claimToken(t, database, organization, adaTurn.InvestigationID), investigation.ToolRun{
 			Ordinal: 1, Tool: "kubernetes.workload_runtime",
 			Purpose:      "compare runtime state with the deploy",
 			HypothesisID: "deployment-trigger",
@@ -494,7 +494,7 @@ func TestConversationsOnOneIncidentShareFindingsAndNothingElse(t *testing.T) {
 		t.Fatalf("recorded purpose metadata = %+v", recordedRuns)
 	}
 	if err = database.ConcludeInvestigation(context.Background(), organization,
-		adaTurn.InvestigationID, investigation.Conclusion{
+		adaTurn.InvestigationID, claimToken(t, database, organization, adaTurn.InvestigationID), investigation.Conclusion{
 			Summary: "ADA-PRIVATE-ANSWER: the pool size changed",
 			Findings: []investigation.Finding{{
 				Statement:  "the deploy at 14:02 changed the pool size",
@@ -603,7 +603,7 @@ func TestTheBriefCarriesWhatEarlierTurnsAlreadyRecommended(t *testing.T) {
 		t.Fatalf("opening a turn: took=%v err=%v", took, err)
 	}
 	if err = database.ConcludeInvestigation(context.Background(), organization,
-		turn.InvestigationID, investigation.Conclusion{
+		turn.InvestigationID, claimToken(t, database, organization, turn.InvestigationID), investigation.Conclusion{
 			Summary: "the 14:02 deploy is the change",
 			Actions: []investigation.ActionProposal{
 				{Title: "roll back the 14:02 deploy"}, {Title: "watch the latency panel"},
@@ -640,7 +640,7 @@ func TestConversationBriefKeepsOnlyTheMostRecentBoundedCitedFindings(t *testing.
 		})
 	}
 	if err = database.ConcludeInvestigation(context.Background(), organization,
-		turn.InvestigationID, investigation.Conclusion{Summary: "completed", Findings: findings},
+		turn.InvestigationID, claimToken(t, database, organization, turn.InvestigationID), investigation.Conclusion{Summary: "completed", Findings: findings},
 		"", investigation.Usage{}); err != nil {
 		t.Fatalf("concluding the turn: %v", err)
 	}
@@ -662,7 +662,7 @@ func TestConversationBriefKeepsOnlyTheMostRecentBoundedCitedFindings(t *testing.
 		t.Fatalf("opening a later turn: took=%v error=%v", took, err)
 	}
 	if err = database.ConcludeInvestigation(context.Background(), organization,
-		next.InvestigationID, investigation.Conclusion{
+		next.InvestigationID, claimToken(t, database, organization, next.InvestigationID), investigation.Conclusion{
 			Summary: "later finding", Findings: []investigation.Finding{
 				{Statement: "newest-turn-finding", Sources: []int{1}},
 			},
@@ -695,7 +695,7 @@ func TestConversationBriefPreservesLimitationsAndOperatorStatementsBeyondOneHund
 		t.Fatalf("opening first turn: took=%t error=%v", took, err)
 	}
 	if err = database.ConcludeInvestigation(ctx, organization, turn.InvestigationID,
-		investigation.Conclusion{Summary: "telemetry remains incomplete",
+		claimToken(t, database, organization, turn.InvestigationID), investigation.Conclusion{Summary: "telemetry remains incomplete",
 			Limitations: []investigation.Limitation{
 				{Type: investigation.LimitationMissingTelemetry,
 					Statement: "database wait telemetry is unavailable"},

--- a/internal/store/postgres/conversation_turn_page_test.go
+++ b/internal/store/postgres/conversation_turn_page_test.go
@@ -22,7 +22,7 @@ func TestConversationDetailBoundsTurns(t *testing.T) {
 			t.Fatalf("opening turn: took=%v err=%v", took, err)
 		}
 		if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID,
-			conclusionSaying("answer"), "", investigation.Usage{}); err != nil {
+			claimToken(t, database, org, turn.InvestigationID), conclusionSaying("answer"), "", investigation.Usage{}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/store/postgres/investigation.go
+++ b/internal/store/postgres/investigation.go
@@ -215,7 +215,7 @@ func (p *Database) QueryInvestigations(
 
 // RecordToolRun writes one execution as it finished.
 func (p *Database) RecordToolRun(
-	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	run investigation.ToolRun,
 ) error {
 	pool, err := p.Pool(organization)
@@ -230,46 +230,59 @@ func (p *Database) RecordToolRun(
 	if err != nil {
 		return fmt.Errorf("encoding a run's sources: %w", err)
 	}
-	_, err = pool.Exec(ctx, `
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err = lockInvestigation(ctx, tx, organization, id); err != nil {
+		return err
+	}
+	tag, err := tx.Exec(ctx, `
 		INSERT INTO investigation_tool_run (investigation_id, org_id,
 		                                    integration_id, ordinal, tool,
 		                                    purpose, hypothesis_id, arguments,
 		                                    window_from, window_until,
 		                                    outcome, truncated, summary, sources, error,
 		                                    started_at, finished_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
+		FROM investigation WHERE investigation_id = $1 AND org_id = $2 AND status = 1
+		AND lease_token = $18 AND lease_expires_at > clock_timestamp()`,
 		id, organization.String(), nullableUUID(run.IntegrationID), run.Ordinal,
 		run.Tool, run.Purpose, run.HypothesisID, arguments, run.WindowFrom, run.WindowUntil,
 		int16(run.Outcome), run.Truncated, run.Summary, sources, run.Error,
-		run.StartedAt, run.FinishedAt)
+		run.StartedAt, run.FinishedAt, token)
 	if err != nil {
 		return fmt.Errorf("recording a tool run: %w", err)
 	}
-	return nil
+	if tag.RowsAffected() == 0 {
+		return investigation.ErrAlreadyEnded
+	}
+	return tx.Commit(ctx)
 }
 
 // ConcludeInvestigation ends one with its concluding document and token usage. stoppedBy
 // names the ceiling that forced the concluding turn, empty when the model concluded
 // freely.
 func (p *Database) ConcludeInvestigation(
-	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	conclusion investigation.Conclusion, stoppedBy string, usage investigation.Usage,
 ) error {
 	encoded, err := json.Marshal(conclusion)
 	if err != nil {
 		return fmt.Errorf("encoding conclusion: %w", err)
 	}
-	return p.endInvestigation(ctx, organization, id, int16(investigation.StatusConcluded),
+	return p.endInvestigation(ctx, organization, id, token, int16(investigation.StatusConcluded),
 		encoded, stoppedBy, "", usage, investigation.EventConcluded,
 		investigation.ConcludedPayload(conclusion, stoppedBy))
 }
 
 // FailInvestigation ends one with the reason it could not conclude.
 func (p *Database) FailInvestigation(
-	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	reason string, usage investigation.Usage,
 ) error {
-	return p.endInvestigation(ctx, organization, id, int16(investigation.StatusFailed),
+	return p.endInvestigation(ctx, organization, id, token, int16(investigation.StatusFailed),
 		[]byte("{}"), "", reason, usage, investigation.EventFailed, investigation.FailedPayload(reason))
 }
 
@@ -288,6 +301,7 @@ func (p *Database) CancelInvestigation(
 				       cancel_requested_at = now(),
 				       cancelled_by = $4,
 				       lease_worker = '',
+				       lease_token = NULL,
 				       lease_expires_at = NULL
 				 WHERE investigation_id = $1 AND org_id = $2 AND status = 1
 				RETURNING `+investigationColumns,
@@ -338,7 +352,7 @@ func (p *Database) CancelInvestigation(
 // endInvestigation is the one write both endings share. Guarded on the row still
 // running, so an investigation cannot be ended twice.
 func (p *Database) endInvestigation(
-	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	status int16, conclusion []byte, stoppedBy, reason string,
 	usage investigation.Usage, eventType investigation.EventType, payload map[string]any,
 ) error {
@@ -355,6 +369,9 @@ func (p *Database) endInvestigation(
 		return fmt.Errorf("beginning terminal transition: %w", err)
 	}
 	defer func() { _ = transaction.Rollback(ctx) }()
+	if err = lockInvestigation(ctx, transaction, organization, id); err != nil {
+		return err
+	}
 	tag, err := transaction.Exec(ctx, `
 		UPDATE investigation
 		   SET status              = $3,
@@ -368,10 +385,12 @@ func (p *Database) endInvestigation(
 		       -- hold, and leaving one behind would make the sweeper reason about work
 		       -- that is already finished.
 		       lease_worker        = '',
+		       lease_token         = NULL,
 		       lease_expires_at    = NULL
-		 WHERE investigation_id = $1 AND org_id = $2 AND status = 1`,
+		 WHERE investigation_id = $1 AND org_id = $2 AND status = 1
+		   AND lease_token = $9 AND lease_expires_at > clock_timestamp()`,
 		id, organization.String(), status, conclusion, stoppedBy,
-		reason, usage.InputTokens, usage.OutputTokens)
+		reason, usage.InputTokens, usage.OutputTokens, token)
 	if err != nil {
 		return fmt.Errorf("ending an investigation: %w", err)
 	}

--- a/internal/store/postgres/investigation_backlog_test.go
+++ b/internal/store/postgres/investigation_backlog_test.go
@@ -122,7 +122,7 @@ func TestConversationDrainDoesNotExceedBacklog(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := database.ConcludeInvestigation(context.Background(), organization,
-		turn.InvestigationID, investigation.Conclusion{Summary: "done"}, "", investigation.Usage{}); err != nil {
+		turn.InvestigationID, claimToken(t, database, organization, turn.InvestigationID), investigation.Conclusion{Summary: "done"}, "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := database.CreateInvestigation(context.Background(), principal, organization,

--- a/internal/store/postgres/investigation_cancellation_test.go
+++ b/internal/store/postgres/investigation_cancellation_test.go
@@ -44,7 +44,7 @@ func TestInvestigationCancellationIsTerminalAttributedAndAudited(t *testing.T) {
 		t.Fatalf("terminal cancellation activity is not safe and explicit: %+v", activity[0])
 	}
 	if err = database.AppendEvent(context.Background(), organization, turn.InvestigationID,
-		investigation.Event{Sequence: 2, At: time.Now().UTC(),
+		claimToken(t, database, organization, turn.InvestigationID), investigation.Event{Sequence: 2, At: time.Now().UTC(),
 			Type: investigation.EventProgress, Payload: map[string]any{"message": "too late"}}); !errors.Is(err, investigation.ErrAlreadyEnded) {
 		t.Fatalf("a remote worker appended activity after the terminal cancellation: %v", err)
 	}

--- a/internal/store/postgres/investigation_claim_fixture_test.go
+++ b/internal/store/postgres/investigation_claim_fixture_test.go
@@ -1,0 +1,37 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/store/postgres"
+)
+
+func claimToken(t *testing.T, database *storage.Database, org tenancy.Organization, id uuid.UUID) uuid.UUID {
+	t.Helper()
+	pool, err := database.Pool(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err = pool.Exec(ctx, `UPDATE investigation
+		SET lease_worker = 'fixture', lease_token = gen_random_uuid(), lease_expires_at = now() + interval '15 minutes'
+		WHERE org_id = $1 AND investigation_id = $2 AND status = 1 AND lease_worker = ''`, org.String(), id); err != nil {
+		t.Fatal(err)
+	}
+	var value *uuid.UUID
+	if err = pool.QueryRow(ctx, `SELECT lease_token FROM investigation WHERE org_id = $1 AND investigation_id = $2`, org.String(), id).Scan(&value); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil
+		}
+		t.Fatal(err)
+	}
+	if value == nil {
+		return uuid.Nil
+	}
+	return *value
+}

--- a/internal/store/postgres/investigation_claim_migration_test.go
+++ b/internal/store/postgres/investigation_claim_migration_test.go
@@ -1,0 +1,53 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestClaimMigrationPreservesLeasedAndQueuedInvestigations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	first := aTurn(t, database, org)
+	second := aTurn(t, database, org)
+	queued := aTurn(t, database, org)
+	for range 2 {
+		if _, _, took, err := database.ClaimInvestigation(ctx, aClaim("same-worker")); err != nil || !took {
+			t.Fatalf("claim: %v %v", took, err)
+		}
+	}
+	pool, err := database.Pool(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `ALTER TABLE investigation DROP COLUMN lease_token; DELETE FROM schema_migration WHERE version = '0006_investigation_claim_token'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	firstToken := claimToken(t, database, org, first)
+	secondToken := claimToken(t, database, org, second)
+	if firstToken == uuid.Nil || secondToken == uuid.Nil || firstToken == secondToken {
+		t.Fatal("retained claims lack distinct tokens")
+	}
+	var queuedToken *uuid.UUID
+	if err = pool.QueryRow(ctx, `SELECT lease_token FROM investigation WHERE org_id = $1 AND investigation_id = $2`, org.String(), queued).Scan(&queuedToken); err != nil || queuedToken != nil {
+		t.Fatalf("queued ownership changed: %v %v", queuedToken, err)
+	}
+	expireInvestigationLease(t, database, org, first)
+	if count, err := database.RecoverStale(ctx, investigation.RecoveryReason, 10); err != nil || count != 1 {
+		t.Fatalf("recovery after migration: %d %v", count, err)
+	}
+	if err = database.ConcludeInvestigation(ctx, org, second, secondToken, conclusionSaying("retained answer"), "", investigation.Usage{}); err != nil {
+		t.Fatal(err)
+	}
+	_, claimed, took, err := database.ClaimInvestigation(ctx, aClaim("same-worker"))
+	if err != nil || !took || claimed.ID != queued || claimed.ClaimToken == uuid.Nil || claimed.ClaimToken == secondToken {
+		t.Fatalf("queued claim after migration: %+v took=%v err=%v", claimed, took, err)
+	}
+}

--- a/internal/store/postgres/investigation_event.go
+++ b/internal/store/postgres/investigation_event.go
@@ -20,11 +20,11 @@ import (
 // than in one answer nobody sized.
 const maxEventPage = 500
 
-// AppendEvent writes one event at the sequence it carries.
+// AppendEvent allocates a durable sequence after locking the Investigation.
 //
 // The parent-row lock serializes progress with terminal transitions across replicas.
 func (p *Database) AppendEvent(
-	ctx context.Context, organization tenancy.Organization, id uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	event investigation.Event,
 ) error {
 	pool, err := p.Pool(organization)
@@ -35,22 +35,31 @@ func (p *Database) AppendEvent(
 	if err != nil {
 		return fmt.Errorf("encoding an event payload: %w", err)
 	}
-	tag, err := pool.Exec(ctx, `
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err = lockInvestigation(ctx, tx, organization, id); err != nil {
+		return err
+	}
+	tag, err := tx.Exec(ctx, `
 		INSERT INTO investigation_event (investigation_id, org_id, sequence, at, type,
 		                                 payload)
-		SELECT $1, $2, $3, $4, $5, $6
+		SELECT $1, $2,
+		       (SELECT coalesce(max(sequence), 0) + 1 FROM investigation_event WHERE investigation_id = $1 AND org_id = $2),
+		       $3, $4, $5
 		  FROM investigation
-		 WHERE investigation_id = $1 AND org_id = $2 AND status = $7
-		 FOR NO KEY UPDATE`,
-		id, organization.String(), event.Sequence, event.At, int16(event.Type),
-		payload, int16(investigation.StatusRunning))
+		 WHERE investigation_id = $1 AND org_id = $2 AND status = 1
+		 AND lease_token = $6 AND lease_expires_at > clock_timestamp()`,
+		id, organization.String(), event.At, int16(event.Type), payload, token)
 	if err != nil {
 		return fmt.Errorf("appending an investigation event: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return investigation.ErrAlreadyEnded
 	}
-	return nil
+	return tx.Commit(ctx)
 }
 
 // Events reports this investigation's events after a sequence, in order.

--- a/internal/store/postgres/investigation_event_test.go
+++ b/internal/store/postgres/investigation_event_test.go
@@ -42,7 +42,7 @@ func appendEvents(
 
 	for position, eventType := range types {
 		if err := database.AppendEvent(context.Background(), organization, id,
-			investigation.Event{
+			claimToken(t, database, organization, id), investigation.Event{
 				Sequence: int64(position + 1),
 				At:       time.Now().UTC(),
 				Type:     eventType,
@@ -120,7 +120,7 @@ func TestAnUnknownFutureEventDoesNotCorruptReadableHistory(t *testing.T) {
 		organization.String(), id); err != nil {
 		t.Fatalf("seeding future history: %v", err)
 	}
-	if err = database.AppendEvent(ctx, organization, id, investigation.Event{
+	if err = database.AppendEvent(ctx, organization, id, claimToken(t, database, organization, id), investigation.Event{
 		Sequence: 2, At: time.Now().UTC(), Type: investigation.EventProgress,
 		Payload: map[string]any{"text": "known history remains readable"},
 	}); err != nil {
@@ -191,7 +191,7 @@ func TestAnEventPayloadSurvivesTheRoundTrip(t *testing.T) {
 		"arguments": map[string]any{"channel": "deploys"},
 	}
 	if err := database.AppendEvent(context.Background(), organization, id,
-		investigation.Event{
+		claimToken(t, database, organization, id), investigation.Event{
 			Sequence: 1, At: time.Now().UTC(),
 			Type: investigation.EventToolStarted, Payload: payload,
 		}); err != nil {
@@ -216,11 +216,7 @@ func TestAnEventPayloadSurvivesTheRoundTrip(t *testing.T) {
 	}
 }
 
-// TWO WRITERS AT ONE POSITION. The lease makes one writer per investigation; the primary
-// key is the backstop for the case where that turns out to be false. A second row at a
-// sequence that already exists is REFUSED rather than silently overwriting the first,
-// because a stream that quietly changed what it already said is worse than one that stops.
-func TestASecondWriterAtTheSameSequenceIsRefused(t *testing.T) {
+func TestAnotherClaimCannotAppendProgress(t *testing.T) {
 	t.Parallel()
 
 	database, organization := migratedDatabase(t)
@@ -231,16 +227,15 @@ func TestASecondWriterAtTheSameSequenceIsRefused(t *testing.T) {
 		Payload: map[string]any{"writer": "the lease holder"},
 	}
 	if err := database.AppendEvent(
-		context.Background(), organization, id, first); err != nil {
+		context.Background(), organization, id, claimToken(t, database, organization, id), first); err != nil {
 		t.Fatalf("the first write failed: %v", err)
 	}
 
 	second := first
 	second.Payload = map[string]any{"writer": "somebody who should not be here"}
 	if err := database.AppendEvent(
-		context.Background(), organization, id, second); err == nil {
-		t.Fatal("a second event at sequence 1 was accepted; the primary key is the " +
-			"backstop against a double-claim and it must refuse")
+		context.Background(), organization, id, uuid.New(), second); err == nil {
+		t.Fatal("another claim appended progress")
 	}
 
 	read, err := database.Events(context.Background(), organization, id, 0, 0)

--- a/internal/store/postgres/investigation_fencing_test.go
+++ b/internal/store/postgres/investigation_fencing_test.go
@@ -1,0 +1,149 @@
+package storage_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestExpiredWorkerCannotConclude(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id := aTurn(t, database, org)
+	if _, _, claimed, err := database.ClaimInvestigation(ctx, aClaim("worker")); err != nil || !claimed {
+		t.Fatalf("claiming: claimed=%v err=%v", claimed, err)
+	}
+	expireInvestigationLease(t, database, org, id)
+	if err := database.ConcludeInvestigation(ctx, org, id, claimToken(t, database, org, id), conclusionSaying("late answer"), "", investigation.Usage{}); err == nil {
+		t.Fatal("expired worker committed a conclusion")
+	}
+	found, err := database.Investigation(ctx, org, id)
+	if err != nil || found.Status != investigation.StatusRunning {
+		t.Fatalf("rejected conclusion changed state: status=%v err=%v", found.Status, err)
+	}
+}
+
+func TestEveryWorkerWriteRequiresItsOwnClaim(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	aTurn(t, database, org)
+	aTurn(t, database, org)
+	_, first, took, err := database.ClaimInvestigation(ctx, aClaim("same-worker"))
+	if err != nil || !took {
+		t.Fatalf("first claim: %v %v", took, err)
+	}
+	_, second, took, err := database.ClaimInvestigation(ctx, aClaim("same-worker"))
+	if err != nil || !took || first.ClaimToken == uuid.Nil || first.ClaimToken == second.ClaimToken {
+		t.Fatalf("claims are not unique: %v %v", took, err)
+	}
+	now := time.Now().UTC()
+	run := investigation.ToolRun{Ordinal: 1, Tool: "read", Purpose: "inspect", Outcome: investigation.RunSucceeded,
+		WindowFrom: now.Add(-time.Hour), WindowUntil: now, StartedAt: now, FinishedAt: now}
+	writes := map[string]func(uuid.UUID) error{
+		"conclusion": func(token uuid.UUID) error {
+			return database.ConcludeInvestigation(ctx, org, first.ID, token, conclusionSaying("answer"), "", investigation.Usage{})
+		},
+		"failure": func(token uuid.UUID) error {
+			return database.FailInvestigation(ctx, org, first.ID, token, "failure", investigation.Usage{})
+		},
+		"tool run": func(token uuid.UUID) error { return database.RecordToolRun(ctx, org, first.ID, token, run) },
+		"progress": func(token uuid.UUID) error {
+			return database.AppendEvent(ctx, org, first.ID, token, investigation.Event{At: now, Type: investigation.EventProgress})
+		},
+	}
+	for _, token := range []uuid.UUID{uuid.Nil, uuid.New(), second.ClaimToken} {
+		for name, write := range writes {
+			if err := write(token); err == nil {
+				t.Errorf("%s accepted another claim", name)
+			}
+		}
+		if held, err := database.Heartbeat(ctx, org, first.ID, investigation.Claim{Worker: "same-worker", LeaseFor: turnWindowLead, Token: token}); err != nil || held {
+			t.Errorf("wrong claim heartbeat: %v %v", held, err)
+		}
+	}
+	if events, err := database.Events(ctx, org, first.ID, 0, 0); err != nil || len(events) != 0 {
+		t.Fatalf("rejected writes left events: %v %v", events, err)
+	}
+	for _, name := range []string{"progress", "tool run", "conclusion"} {
+		if err := writes[name](first.ClaimToken); err != nil {
+			t.Fatalf("valid %s: %v", name, err)
+		}
+	}
+	for name, write := range writes {
+		if err := write(first.ClaimToken); err == nil {
+			t.Errorf("terminal claim accepted %s", name)
+		}
+	}
+	events, err := database.Events(ctx, org, first.ID, 0, 0)
+	if err != nil || len(events) != 2 || events[0].Sequence != 1 || events[1].Sequence != 2 || !events[1].Type.Terminal() {
+		t.Fatalf("canonical ending: %+v %v", events, err)
+	}
+}
+
+func TestConcurrentClaimWritesReceiveDurableSequences(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id := aTurn(t, database, org)
+	_, opened, claimed, err := database.ClaimInvestigation(ctx, aClaim("worker"))
+	if err != nil || !claimed {
+		t.Fatalf("claiming: claimed=%v err=%v", claimed, err)
+	}
+	var workers sync.WaitGroup
+	for range 10 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			if err := database.AppendEvent(ctx, org, id, opened.ClaimToken, investigation.Event{Sequence: 1, At: time.Now(), Type: investigation.EventProgress}); err != nil {
+				t.Errorf("append: %v", err)
+			}
+		}()
+	}
+	workers.Wait()
+	events, err := database.Events(ctx, org, id, 0, 0)
+	if err != nil || len(events) != 10 {
+		t.Fatalf("events=%d err=%v", len(events), err)
+	}
+	for index, event := range events {
+		if event.Sequence != int64(index+1) {
+			t.Fatalf("position %d has sequence %d", index, event.Sequence)
+		}
+	}
+}
+
+func TestExpiredWorkerCannotRecordToolRun(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id := aTurn(t, database, org)
+	if _, _, claimed, err := database.ClaimInvestigation(ctx, aClaim("worker")); err != nil || !claimed {
+		t.Fatalf("claiming: claimed=%v err=%v", claimed, err)
+	}
+	expireInvestigationLease(t, database, org, id)
+	now := time.Now().UTC()
+	run := investigation.ToolRun{Ordinal: 1, Tool: "read", Purpose: "inspect", Outcome: investigation.RunSucceeded,
+		WindowFrom: now.Add(-time.Hour), WindowUntil: now, StartedAt: now, FinishedAt: now}
+	if err := database.RecordToolRun(ctx, org, id, claimToken(t, database, org, id), run); err == nil {
+		t.Fatal("expired worker persisted a Tool Run")
+	}
+}
+
+func TestExpiredWorkerCannotAppendProgress(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id := aTurn(t, database, org)
+	if _, _, claimed, err := database.ClaimInvestigation(ctx, aClaim("worker")); err != nil || !claimed {
+		t.Fatalf("claiming: claimed=%v err=%v", claimed, err)
+	}
+	expireInvestigationLease(t, database, org, id)
+	if err := database.AppendEvent(ctx, org, id, claimToken(t, database, org, id), investigation.Event{Sequence: 1, At: time.Now(), Type: investigation.EventProgress}); err == nil {
+		t.Fatal("expired worker appended progress")
+	}
+}

--- a/internal/store/postgres/investigation_lease.go
+++ b/internal/store/postgres/investigation_lease.go
@@ -21,6 +21,7 @@ func (p *Database) ClaimInvestigation(
 	row := p.pool.QueryRow(ctx, `
 			UPDATE investigation
 			   SET lease_worker       = $1,
+			       lease_token        = gen_random_uuid(),
 			       lease_expires_at   = now() + $2::interval
 			 WHERE investigation_id = (
 			       SELECT waiting.investigation_id
@@ -30,7 +31,7 @@ func (p *Database) ClaimInvestigation(
 			        ORDER BY waiting.created_at, waiting.investigation_id
 			        LIMIT 1
 			        FOR UPDATE SKIP LOCKED)
-			RETURNING org_id, `+investigationColumns,
+			RETURNING org_id, lease_token, `+investigationColumns,
 		claim.Worker, claim.LeaseFor.String())
 
 	var organization string
@@ -60,17 +61,32 @@ func (p *Database) Heartbeat(
 	if err != nil {
 		return false, err
 	}
-	tag, err := pool.Exec(ctx, `
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err = lockInvestigation(ctx, tx, organization, id); err != nil {
+		if errors.Is(err, investigation.ErrUnknown) {
+			return false, nil
+		}
+		return false, err
+	}
+	tag, err := tx.Exec(ctx, `
 		UPDATE investigation
-		   SET lease_expires_at = now() + $4::interval
+		   SET lease_expires_at = clock_timestamp() + $4::interval
 		 WHERE investigation_id = $1
 		   AND org_id           = $2
 		   AND status           = 1
 		   AND lease_worker     = $3
-		   AND lease_expires_at > now()`,
-		id, organization.String(), claim.Worker, claim.LeaseFor.String())
+		   AND lease_token      = $5
+		   AND lease_expires_at > clock_timestamp()`,
+		id, organization.String(), claim.Worker, claim.LeaseFor.String(), claim.Token)
 	if err != nil {
 		return false, fmt.Errorf("renewing an investigation lease: %w", err)
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return false, err
 	}
 	return tag.RowsAffected() == 1, nil
 }
@@ -123,6 +139,7 @@ func recoverStaleIn(
 		       error            = $1,
 		       concluded_at     = now(),
 		       lease_worker     = '',
+		       lease_token      = NULL,
 		       lease_expires_at = NULL
 		 WHERE investigation_id IN (
 		       SELECT lapsed.investigation_id
@@ -184,21 +201,23 @@ func recoverStaleIn(
 	return len(swept), nil
 }
 
-// scanClaimedInvestigation reads a claimed row, whose first column is the organization it
-// belongs to — the claimer asked no tenant in particular and has to be told.
+// scanClaimedInvestigation includes the Organization and claim token returned by leasing.
 func scanClaimedInvestigation(
 	row scanned, organization *string,
 ) (investigation.Investigation, error) {
-	return scanInvestigation(prefixedRow{row: row, first: organization}, "")
+	var token uuid.UUID
+	found, err := scanInvestigation(prefixedRow{row: row, first: organization, token: &token}, "")
+	found.ClaimToken = token
+	return found, err
 }
 
-// prefixedRow lets the shared investigation mapping serve a query that returns one extra
-// leading column, without a second copy of an eighteen-column scan.
+// prefixedRow preserves the shared Investigation mapping after the claim metadata.
 type prefixedRow struct {
 	row   scanned
 	first *string
+	token *uuid.UUID
 }
 
 func (p prefixedRow) Scan(destination ...any) error {
-	return p.row.Scan(append([]any{p.first}, destination...)...)
+	return p.row.Scan(append([]any{p.first, p.token}, destination...)...)
 }

--- a/internal/store/postgres/investigation_lease_expiry_test.go
+++ b/internal/store/postgres/investigation_lease_expiry_test.go
@@ -22,6 +22,7 @@ func TestExpiredLeaseCannotBeRenewedBeforeRecovery(t *testing.T) {
 		t.Fatalf("claiming: took=%v err=%v", took, err)
 	}
 	expireInvestigationLease(t, database, organization, turn.InvestigationID)
+	claim.Token = claimToken(t, database, organization, turn.InvestigationID)
 	if held, err := database.Heartbeat(ctx, organization, turn.InvestigationID, claim); err != nil || held {
 		t.Fatalf("expired lease renewed: held=%v err=%v", held, err)
 	}

--- a/internal/store/postgres/investigation_lease_test.go
+++ b/internal/store/postgres/investigation_lease_test.go
@@ -157,7 +157,7 @@ func TestHeartbeatIsFencedByWorkerIdentity(t *testing.T) {
 		t.Fatalf("another worker renewed the lease: held=%v err=%v", held, heartbeatErr)
 	}
 	if held, heartbeatErr := database.Heartbeat(context.Background(), organization,
-		turn.InvestigationID, aClaim("worker-a")); heartbeatErr != nil || !held {
+		turn.InvestigationID, investigation.Claim{Worker: "worker-a", LeaseFor: turnWindowLead, Token: claimToken(t, database, organization, turn.InvestigationID)}); heartbeatErr != nil || !held {
 		t.Fatalf("the holder could not renew its lease: held=%v err=%v", held, heartbeatErr)
 	}
 }
@@ -183,7 +183,7 @@ func TestALapsedLeaseFailsTheInvestigationAndEndsItsStream(t *testing.T) {
 	}
 	// The worker got as far as saying it had started, and then stopped existing.
 	if err = database.AppendEvent(context.Background(), organization,
-		turn.InvestigationID, investigation.Event{
+		turn.InvestigationID, claimToken(t, database, organization, turn.InvestigationID), investigation.Event{
 			Sequence: 1, At: time.Now().UTC(), Type: investigation.EventStarted,
 			Payload: map[string]any{"state": "executing"},
 		}); err != nil {
@@ -286,7 +286,7 @@ func TestConcludingReleasesTheLease(t *testing.T) {
 	}
 
 	if err = database.ConcludeInvestigation(context.Background(), organization,
-		turn.InvestigationID, conclusionSaying("done"), "",
+		turn.InvestigationID, claimToken(t, database, organization, turn.InvestigationID), conclusionSaying("done"), "",
 		investigation.Usage{}); err != nil {
 		t.Fatalf("concluding: %v", err)
 	}
@@ -322,11 +322,11 @@ func TestTerminalInvestigationUsageRoundTrips(t *testing.T) {
 	}{
 		{name: "concluded", end: func(id uuid.UUID, usage investigation.Usage) error {
 			return database.ConcludeInvestigation(context.Background(), organization, id,
-				conclusionSaying("done"), "", usage)
+				claimToken(t, database, organization, id), conclusionSaying("done"), "", usage)
 		}},
 		{name: "failed", end: func(id uuid.UUID, usage investigation.Usage) error {
 			return database.FailInvestigation(context.Background(), organization, id,
-				"provider unavailable", usage)
+				claimToken(t, database, organization, id), "provider unavailable", usage)
 		}},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/store/postgres/investigation_lock.go
+++ b/internal/store/postgres/investigation_lock.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+// Lock before checking ownership so time spent waiting cannot revive an expired claim.
+func lockInvestigation(ctx context.Context, tx pgx.Tx, org tenancy.Organization, id uuid.UUID) error {
+	var found int
+	err := tx.QueryRow(ctx, `SELECT 1 FROM investigation WHERE org_id = $1 AND investigation_id = $2 FOR NO KEY UPDATE`, org.String(), id).Scan(&found)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return investigation.ErrUnknown
+	}
+	return err
+}

--- a/internal/store/postgres/investigation_stream_test.go
+++ b/internal/store/postgres/investigation_stream_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
 	"github.com/open-cluster/oc-control-plane/internal/investigation"
 )
 
@@ -18,7 +20,10 @@ func TestFailedEventWritePreservesStreamStateForRetry(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			stream := investigation.NewEventStream(database.AppendEvent, nil, org, id)
+			token := claimToken(t, database, org, id)
+			stream := investigation.NewEventStream(func(ctx context.Context, org tenancy.Organization, id uuid.UUID, event investigation.Event) error {
+				return database.AppendEvent(ctx, org, id, token, event)
+			}, nil, org, id)
 			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event ADD CONSTRAINT reject_stream_test CHECK (type NOT IN (2, 7))`); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/store/postgres/investigation_terminal_test.go
+++ b/internal/store/postgres/investigation_terminal_test.go
@@ -18,7 +18,7 @@ func TestConclusionCommitsItsReplayEvent(t *testing.T) {
 		t.Fatalf("opening turn: took=%v err=%v", took, err)
 	}
 	if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID,
-		conclusionSaying("canonical answer"), "", investigation.Usage{}); err != nil {
+		claimToken(t, database, org, turn.InvestigationID), conclusionSaying("canonical answer"), "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	events, err := database.Events(ctx, org, turn.InvestigationID, 0, 0)
@@ -52,9 +52,9 @@ func TestTerminalEventFailureRollsBackOutcome(t *testing.T) {
 			}
 			finish := func() error {
 				if failure {
-					return database.FailInvestigation(ctx, org, turn.InvestigationID, "provider unavailable", investigation.Usage{InputTokens: 42})
+					return database.FailInvestigation(ctx, org, turn.InvestigationID, claimToken(t, database, org, turn.InvestigationID), "provider unavailable", investigation.Usage{InputTokens: 42})
 				}
-				return database.ConcludeInvestigation(ctx, org, turn.InvestigationID, conclusionSaying("answer"), "", investigation.Usage{InputTokens: 42})
+				return database.ConcludeInvestigation(ctx, org, turn.InvestigationID, claimToken(t, database, org, turn.InvestigationID), conclusionSaying("answer"), "", investigation.Usage{InputTokens: 42})
 			}
 			if err = finish(); err == nil {
 				t.Fatal("terminal event failure was swallowed")
@@ -90,10 +90,10 @@ func TestLateProgressCannotFollowCompletion(t *testing.T) {
 	if err != nil || !took {
 		t.Fatalf("opening turn: took=%v err=%v", took, err)
 	}
-	if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID, conclusionSaying("done"), "", investigation.Usage{}); err != nil {
+	if err = database.ConcludeInvestigation(ctx, org, turn.InvestigationID, claimToken(t, database, org, turn.InvestigationID), conclusionSaying("done"), "", investigation.Usage{}); err != nil {
 		t.Fatal(err)
 	}
-	if err = database.AppendEvent(ctx, org, turn.InvestigationID, investigation.Event{Sequence: 2, Type: investigation.EventProgress}); err == nil {
+	if err = database.AppendEvent(ctx, org, turn.InvestigationID, claimToken(t, database, org, turn.InvestigationID), investigation.Event{Sequence: 2, Type: investigation.EventProgress}); err == nil {
 		t.Fatal("completed Investigation accepted late activity")
 	}
 }

--- a/internal/store/postgres/migrations/0006_investigation_claim_token.sql
+++ b/internal/store/postgres/migrations/0006_investigation_claim_token.sql
@@ -1,0 +1,6 @@
+ALTER TABLE investigation ADD COLUMN lease_token uuid;
+
+UPDATE investigation SET lease_token = gen_random_uuid() WHERE lease_worker <> '';
+
+ALTER TABLE investigation ADD CONSTRAINT investigation_lease_token_is_whole
+    CHECK ((lease_worker = '') = (lease_token IS NULL));

--- a/test/architecture/persisted_enum_test.go
+++ b/test/architecture/persisted_enum_test.go
@@ -249,6 +249,7 @@ var enumColumns = map[string]map[string][]int{
 	// the recovery sweep fails it — so the file writes an investigation status as a
 	// literal twice, in the two places that mean the most.
 	"investigation_lease.go": {"status": investigationStatusValues},
+	"investigation_event.go": {"status": investigationStatusValues},
 	// Opening a turn counts INVESTIGATIONS that are still running and derives the window
 	// from whether the EPISODE is still open, so the same two enums share this file too.
 	// The queued-message reads filter on a MESSAGE's role, because only what a person


### PR DESCRIPTION
Expired workers could still conclude, record Tool Runs and append activity. Each Investigation claim now receives a unique UUID token, passed explicitly through Runner and Agent writes. Terminal, Tool Run, event and heartbeat writes lock the Investigation before checking Organization, lifecycle, token and current expiry. Cancellation and recovery clear ownership atomically with their existing terminal transaction.

Progress sequences are allocated by PostgreSQL after acquiring the same row lock, preserving historical gaps and avoiding collisions between valid concurrent writes. Failed writes consume no durable sequence. Claim tokens are excluded from JSON views.

Migration 0006 adds lease_token, backfills held leases and constrains complete ownership metadata. Stop old control-plane replicas before upgrading; interrupted work is recovered as failed rather than resumed by an older worker.

Validation: real PostgreSQL RED/GREEN for expired terminal/Tool Run/progress writes and concurrent sequence collisions; missing/foreign/terminal token rejection; retained leased/queued migration; rollback/replay regressions. Full race suites pass, including PostgreSQL (176s) and composed control plane (402s). Formatting, vet, lint, builds, OpenAPI/docs, vulnerability and license checks, backend image and secret scan pass. Independent standards and spec reviews found no actionable issues; GitHub CI passes. Local make verify still fails at the existing frontend COPY web/ step, so the release gate is not claimed green.

Part of issue #48 phase 2. SSE deadline/proxy behavior and typed event validation follow within this phase. Issue #48 remains incomplete. The existing missing web/ frontend packaging failure remains a separate release blocker.
