### PR TITLE
Bound SSE writes and close streams during shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Follow-ups receive a bounded recent exchange of Messages and completed answers, 
 timestamps and source identities retained.
 Terminal outcomes and their replay events commit together; failed event writes cannot
 leave a completed result without its ending event.
+Event streams refresh bounded write deadlines, survive ordinary HTTP timeouts, and close
+during shutdown. Proxy buffering and timeout requirements are in the
+[API reference](./docs/api-reference/overview.mdx#investigation-event-streams).
 Expired worker leases cannot be renewed; recovery ends the interrupted Investigation.
 Each claim has a unique token fencing progress, Tool Runs and terminal writes. PostgreSQL
 allocates replay sequences under the same Investigation lock used by terminal transitions.

--- a/deploy/compose/frontend-nginx.conf
+++ b/deploy/compose/frontend-nginx.conf
@@ -21,6 +21,8 @@ http {
             proxy_pass http://control-plane:8080;
             proxy_http_version 1.1;
             proxy_buffering off;
+            proxy_read_timeout 60s;
+            send_timeout 10s;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -120,6 +120,16 @@ Investigation activity uses increasing sequence identifiers. SSE clients reconne
 `Last-Event-ID`; comment frames are heartbeats and carry no product event. Store the last
 processed sequence only after handling its event successfully.
 
+Streams send an idle heartbeat every 15 seconds and can stay open beyond ordinary HTTP
+request timeouts. Each event batch has a 10-second write deadline; a stalled connection
+is dropped and can reconnect using its last processed sequence. Streams close on a terminal
+event, an already processed terminal cursor, or server shutdown. Reconnect after shutdown
+to resume from durable activity.
+
+Reverse proxies must disable response buffering and allow at least 60 seconds between
+upstream reads. The supplied nginx configuration uses `proxy_buffering off`,
+`proxy_read_timeout 60s`, and `send_timeout 10s` to bound stalled downstream clients.
+
 Terminal events are `concluded`, `failed`, and `cancelled`. Ignore an unknown future event
 type while retaining its envelope so a newer server remains compatible with an older
 client. The generated stream operation documents every currently shipped event payload.

--- a/internal/api/operator.go
+++ b/internal/api/operator.go
@@ -33,6 +33,7 @@ type Handlers struct {
 	Identity                identity.Handlers
 	Catalog                 integrations.Catalog
 	Investigations          *investigation.Runner
+	StreamContext           context.Context
 	InvestigationWindowLead time.Duration
 	Sealer                  seal.Sealer
 	ConversationsEnabled    bool
@@ -124,11 +125,12 @@ func (h Handlers) Routes() authz.Table {
 		Logger:  h.Logger,
 	}.Routes()...)
 	routes = append(routes, investigation.Handlers{
-		Store:      h.Database,
-		Runner:     h.Investigations,
-		Logger:     h.Logger,
-		WindowLead: h.InvestigationWindowLead,
-		MaxPending: h.MaxWaitingTurns,
+		Store:         h.Database,
+		Runner:        h.Investigations,
+		StreamContext: h.StreamContext,
+		Logger:        h.Logger,
+		WindowLead:    h.InvestigationWindowLead,
+		MaxPending:    h.MaxWaitingTurns,
 	}.Routes()...)
 	routes = append(routes, conversation.Handlers{
 		Store:           h.Database,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -255,6 +255,7 @@ func inventoryInterval(replacement time.Duration) time.Duration {
 // assembled is the constructed process: the pieces serve needs, which are meaningless
 // apart and always travel together.
 type assembled struct {
+	streamContext     context.Context
 	config            config.Config
 	logger            *slog.Logger
 	telemetry         *observability.Telemetry

--- a/internal/app/http.go
+++ b/internal/app/http.go
@@ -26,6 +26,7 @@ import (
 // serve opens the listener and runs the HTTP surface until ctx is cancelled, then drains.
 func serve(ctx context.Context, process assembled) error {
 	cfg, logger := process.config, process.logger
+	process.streamContext = ctx
 
 	handler, err := httpRoutes(process)
 	if err != nil {
@@ -179,6 +180,7 @@ func operatorRouter(process assembled) (http.Handler, error) {
 		Catalog:                 process.catalog,
 		Sealer:                  process.sealer,
 		Investigations:          process.investigations,
+		StreamContext:           process.streamContext,
 		InvestigationWindowLead: defaultInvestigationWindowLead,
 		ConversationsEnabled:    true,
 		MaxWaitingTurns:         cfg.MaxPendingInvestigationsPerOrganization,

--- a/internal/investigation/events.go
+++ b/internal/investigation/events.go
@@ -388,7 +388,8 @@ const (
 	eventPollInterval = 500 * time.Millisecond
 	// eventHeartbeat keeps an idle connection from being reaped by whatever sits in front
 	// of it. A comment line is not an event and no reader has to know about it.
-	eventHeartbeat = 15 * time.Second
+	eventHeartbeat    = 15 * time.Second
+	eventWriteTimeout = 10 * time.Second
 	// eventStreamLifetime bounds one connection. It is the investigation's own ceiling
 	// plus room to see the ending: a stream that outlived every possible investigation
 	// would be a connection held open for nothing.
@@ -401,6 +402,13 @@ const (
 // another organization answers not-found with the same body as one that never existed,
 // before a single event is read — the boundary must not depend on the stream being empty.
 func (h Handlers) streamEvents(writer http.ResponseWriter, request *http.Request) {
+	if h.StreamContext != nil {
+		ctx, cancel := context.WithCancel(request.Context())
+		defer cancel()
+		stop := context.AfterFunc(h.StreamContext, cancel)
+		defer stop()
+		request = request.WithContext(ctx)
+	}
 	_, ok := h.caller(writer, request)
 	if !ok {
 		return
@@ -432,14 +440,12 @@ func (h Handlers) streamEvents(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	flusher, streaming := writer.(http.Flusher)
-	if !streaming {
-		// Without flushing, every event would arrive at once when the handler returned,
-		// which is the opposite of what this is for.
+	controller := http.NewResponseController(writer)
+	if err := controller.SetWriteDeadline(time.Now().Add(eventWriteTimeout)); err != nil {
 		writeJSON(writer, http.StatusInternalServerError,
 			errorView{Error: "request failed"})
 		h.Logger.ErrorContext(request.Context(),
-			"the event stream is mounted behind a writer that cannot flush")
+			"the event stream is mounted behind a writer without write deadlines")
 		return
 	}
 
@@ -449,15 +455,19 @@ func (h Handlers) streamEvents(writer http.ResponseWriter, request *http.Request
 	// silent minute followed by everything.
 	writer.Header().Set("X-Accel-Buffering", "no")
 	writer.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	if err := controller.Flush(); err != nil {
+		return
+	}
+	// net/http must still flush the response ending after an idle shutdown.
+	defer func() { _ = controller.SetWriteDeadline(time.Now().Add(eventWriteTimeout)) }()
 
-	h.follow(request, writer, flusher, organization, found, after)
+	h.follow(request, writer, controller, organization, found, after)
 }
 
 // follow drains what is already recorded and then keeps draining until the investigation
 // ends, the connection goes, or the lifetime is up.
 func (h Handlers) follow(
-	request *http.Request, writer http.ResponseWriter, flusher http.Flusher,
+	request *http.Request, writer http.ResponseWriter, controller *http.ResponseController,
 	organization tenancy.Organization, found Investigation, after int64,
 ) {
 	ctx := request.Context()
@@ -465,6 +475,9 @@ func (h Handlers) follow(
 	lastHeartbeat := time.Now()
 
 	for {
+		if ctx.Err() != nil || time.Now().After(deadline) {
+			return
+		}
 		readCtx, cancel := context.WithTimeout(request.Context(), readTimeout)
 		events, err := h.Store.Events(readCtx, organization, found.ID, after, 0)
 		cancel()
@@ -474,7 +487,27 @@ func (h Handlers) follow(
 				slog.String("error", err.Error()))
 			return
 		}
+		if len(events) == 0 {
+			if found.Status != StatusRunning {
+				return
+			}
+			readCtx, cancel = context.WithTimeout(ctx, readTimeout)
+			found, err = h.Store.Investigation(readCtx, organization, found.ID)
+			cancel()
+			if err != nil {
+				return
+			}
+			if found.Status != StatusRunning {
+				// Re-read events after observing completion to include its committed ending.
+				continue
+			}
+		}
 
+		if len(events) > 0 {
+			if err := controller.SetWriteDeadline(time.Now().Add(eventWriteTimeout)); err != nil {
+				return
+			}
+		}
 		for _, event := range events {
 			if err := writeEvent(writer, envelopeOf(organization, found, event)); err != nil {
 				// The reader is gone. That is the ordinary way a stream ends.
@@ -485,12 +518,14 @@ func (h Handlers) follow(
 				// Nothing follows a terminal event, so the connection has served its whole
 				// purpose. Holding it open would be a client waiting for something this
 				// investigation will never produce.
-				flusher.Flush()
+				_ = controller.Flush()
 				return
 			}
 		}
 		if len(events) > 0 {
-			flusher.Flush()
+			if err := controller.Flush(); err != nil {
+				return
+			}
 			lastHeartbeat = time.Now()
 			// A full page means there is probably more waiting; read again rather than
 			// sleeping through a backlog.
@@ -500,16 +535,18 @@ func (h Handlers) follow(
 		}
 
 		if time.Since(lastHeartbeat) >= eventHeartbeat {
+			if err := controller.SetWriteDeadline(time.Now().Add(eventWriteTimeout)); err != nil {
+				return
+			}
 			if _, err := fmt.Fprint(writer, ": keep-alive\n\n"); err != nil {
 				return
 			}
-			flusher.Flush()
+			if err := controller.Flush(); err != nil {
+				return
+			}
 			lastHeartbeat = time.Now()
 		}
 
-		if time.Now().After(deadline) {
-			return
-		}
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/investigation/handler.go
+++ b/internal/investigation/handler.go
@@ -28,6 +28,8 @@ type Handlers struct {
 	Runner     *Runner
 	Logger     *slog.Logger
 	MaxPending int
+	// StreamContext stops long-lived streams while ordinary requests drain at shutdown.
+	StreamContext context.Context
 	// WindowLead widens an investigation's window before the incident began: the change
 	// that caused an incident usually landed before it fired. Configuration, because the
 	// right lead follows an organization's deploy cadence, not a constant.

--- a/test/controlplane/event_lifecycle_test.go
+++ b/test/controlplane/event_lifecycle_test.go
@@ -1,0 +1,139 @@
+package controlplane
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-cluster/oc-control-plane/internal/auth/session"
+)
+
+func TestEventStreamClosesAfterTerminalCursor(t *testing.T) {
+	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	_, turn := plane.openConversation(t, "replayed stream", "investigate checkout")
+	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations/"+turn+"/cancel", nil)
+	if status != http.StatusOK {
+		t.Fatalf("cancel = %d: %s", status, body)
+	}
+	response := openEventStream(t, plane, turn, "?after=1")
+	defer func() { _ = response.Body.Close() }()
+	finished := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, response.Body)
+		finished <- err
+	}()
+	select {
+	case err := <-finished:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("a cursor after the terminal event left the stream open")
+	}
+}
+
+func TestEventStreamClosesDuringGracefulShutdown(t *testing.T) {
+	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	_, turn := plane.openConversation(t, "shutdown stream", "investigate checkout")
+	response := openEventStream(t, plane, turn, "")
+	defer func() { _ = response.Body.Close() }()
+	plane.shutdown()
+	if plane.exitErr != nil {
+		t.Fatalf("shutdown with a live event stream: %v", plane.exitErr)
+	}
+	if _, err := io.ReadAll(response.Body); err != nil {
+		t.Fatalf("stream was interrupted instead of closing cleanly: %v", err)
+	}
+}
+
+func TestEventStreamSurvivesOrdinaryWriteTimeout(t *testing.T) {
+	t.Parallel()
+	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	assertLiveEventStream(t, plane, plane)
+}
+
+func TestEventStreamThroughSupportedProxy(t *testing.T) {
+	t.Parallel()
+	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	proxied := *plane
+	proxied.operator = startEventProxy(t, plane.operator)
+	assertLiveEventStream(t, plane, &proxied)
+	_, turn := plane.openConversation(t, "proxy shutdown", "investigate checkout")
+	response := openEventStream(t, &proxied, turn, "")
+	defer func() { _ = response.Body.Close() }()
+	plane.shutdown()
+	if plane.exitErr != nil {
+		t.Fatalf("shutdown through proxy: %v", plane.exitErr)
+	}
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatalf("proxy stream did not close cleanly: %v", err)
+	}
+}
+
+func assertLiveEventStream(t *testing.T, plane, streamed *integrationPlane) {
+	t.Helper()
+	_, turn := plane.openConversation(t, "live stream", "investigate checkout")
+	response := openEventStream(t, streamed, turn, "")
+	defer func() { _ = response.Body.Close() }()
+	scanner := bufio.NewScanner(response.Body)
+	heartbeats := 0
+	for scanner.Scan() {
+		if scanner.Text() == ": keep-alive" {
+			heartbeats++
+			if heartbeats == 3 {
+				break
+			}
+		}
+	}
+	if heartbeats != 3 {
+		t.Fatalf("stream ended after %d heartbeats: %v", heartbeats, scanner.Err())
+	}
+	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations/"+turn+"/cancel", nil)
+	if status != http.StatusOK {
+		t.Fatalf("cancel = %d: %s", status, body)
+	}
+	ending := false
+	for scanner.Scan() {
+		ending = ending || strings.HasPrefix(scanner.Text(), "event: cancelled")
+	}
+	if scanner.Err() != nil || !ending {
+		t.Fatalf("cancelled stream did not close with its ending: ending=%v, error=%v", ending, scanner.Err())
+	}
+	replay := openEventStream(t, streamed, turn, "", http.Header{"Last-Event-Id": {"1"}})
+	defer func() { _ = replay.Body.Close() }()
+	bodyBytes, err := io.ReadAll(replay.Body)
+	if err != nil || len(bodyBytes) != 0 {
+		t.Fatalf("terminal cursor replay = %q, error=%v", bodyBytes, err)
+	}
+}
+
+func openEventStream(t *testing.T, plane *integrationPlane, turn, query string, headers ...http.Header) *http.Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 65*time.Second)
+	t.Cleanup(cancel)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		plane.base(surfaceOrg)+"/investigations/"+turn+"/events"+query, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.AddCookie(&http.Cookie{Name: session.CookieName, Value: plane.sessionCookie})
+	selectOrganizationFromURL(request)
+	for _, supplied := range headers {
+		for name, values := range supplied {
+			request.Header[name] = values
+		}
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		_ = response.Body.Close()
+		t.Fatalf("stream status = %d", response.StatusCode)
+	}
+	return response
+}

--- a/test/controlplane/event_proxy_test.go
+++ b/test/controlplane/event_proxy_test.go
@@ -1,0 +1,67 @@
+package controlplane
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func startEventProxy(t *testing.T, backend string) string {
+	t.Helper()
+	configuration, err := os.ReadFile("../../deploy/compose/frontend-nginx.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostPort, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configuration = []byte(strings.ReplaceAll(string(configuration), "control-plane:8080",
+		net.JoinHostPort(testcontainers.HostInternal, port)))
+	path := filepath.Join(t.TempDir(), "nginx.conf")
+	if err := os.WriteFile(path, configuration, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		Started: true,
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:           "nginxinc/nginx-unprivileged:1.27-alpine",
+			ExposedPorts:    []string{"8080/tcp"},
+			HostAccessPorts: []int{hostPort},
+			Files: []testcontainers.ContainerFile{{
+				HostFilePath: path, ContainerFilePath: "/etc/nginx/nginx.conf", FileMode: 0o644,
+			}},
+			WaitingFor: wait.ForListeningPort("8080/tcp").WithStartupTimeout(time.Minute),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Error(err)
+		}
+	})
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapped, err := container.MappedPort(ctx, "8080/tcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return net.JoinHostPort(host, mapped.Port())
+}

--- a/test/controlplane/event_slow_reader_test.go
+++ b/test/controlplane/event_slow_reader_test.go
@@ -1,0 +1,130 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/sha256"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/auth/session"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+)
+
+func TestEventStreamBoundsSlowReaders(t *testing.T) {
+	for _, proxy := range []bool{false, true} {
+		name := "listener"
+		if proxy {
+			name = "proxy"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			address := freeAddress(t)
+			var dsn string
+			running := startControlPlaneRunning(t, func(cfg *config.Config) {
+				cfg.HTTPAddress = address
+				digest := sha256.Sum256([]byte(surfaceToken))
+				cfg.OperatorTokenDigest = digest[:]
+				dsn = cfg.DatabaseDSN
+			}, app.Options{Agent: &blockingAgentMain{started: make(chan struct{}, 1)}})
+			plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+			_, turn := plane.openConversation(t, "large replay", "investigate checkout")
+			seedEventBacklog(t, dsn, turn)
+			status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations/"+turn+"/cancel", nil)
+			if status != http.StatusOK {
+				t.Fatalf("cancel = %d: %s", status, body)
+			}
+			if proxy {
+				plane.operator = startEventProxy(t, address)
+			}
+			assertSlowEventReader(t, plane, turn)
+		})
+	}
+}
+
+func seedEventBacklog(t *testing.T, dsn, turn string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	connection, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = connection.Close(context.Background()) }()
+	_, err = connection.Exec(ctx, `INSERT INTO investigation_event
+		(investigation_id, org_id, sequence, at, type, payload)
+		SELECT $1, $2, sequence, clock_timestamp(), 2, jsonb_build_object('text', repeat('x', 512))
+		FROM generate_series(1, 20000) AS sequence`, turn, surfaceOrg)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertSlowEventReader(t *testing.T, plane *integrationPlane, turn string) {
+	t.Helper()
+	connection, err := net.DialTCP("tcp", nil, mustTCPAddress(t, plane.operator))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = connection.Close() }()
+	if err := connection.SetReadBuffer(1024); err != nil {
+		t.Fatal(err)
+	}
+	transport := &http.Transport{DialContext: func(context.Context, string, string) (net.Conn, error) {
+		return connection, nil
+	}}
+	defer transport.CloseIdleConnections()
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		plane.base(surfaceOrg)+"/investigations/"+turn+"/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.AddCookie(&http.Cookie{Name: session.CookieName, Value: plane.sessionCookie})
+	selectOrganizationFromURL(request)
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("stream status=%d", response.StatusCode)
+	}
+	time.Sleep(15 * time.Second)
+	if err := connection.SetReadBuffer(1 << 20); err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err == nil || strings.Contains(string(body), "event: cancelled") {
+		t.Fatalf("slow reader remained connected: bytes=%d, error=%v", len(body), err)
+	}
+	if timeout, ok := err.(net.Error); ok && timeout.Timeout() {
+		t.Fatalf("server did not close the slow reader: %v", err)
+	}
+	// A normal reconnect can still reach the durable ending after the slow connection closes.
+	replay := openEventStream(t, plane, turn, "?after=20000")
+	defer func() { _ = replay.Body.Close() }()
+	ending, err := io.ReadAll(replay.Body)
+	if err != nil || !strings.Contains(string(ending), "event: cancelled") {
+		t.Fatalf("reconnect lost the terminal event: %q, error=%v", ending, err)
+	}
+}
+
+func mustTCPAddress(t *testing.T, address string) *net.TCPAddr {
+	t.Helper()
+	resolved, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}


### PR DESCRIPTION
SSE inherited the ordinary 30-second response timeout, ignored flush errors, and held shutdown open. Streams now use ResponseController write deadlines and flush errors, receive a stream-only shutdown context, and close after an already processed terminal cursor. Ordinary HTTP deadlines and request draining remain in place. Completion observed after an empty event read triggers another read before closure so its ending cannot be lost.

The supported nginx configuration disables buffering, allows 60 seconds between upstream reads, and disconnects stalled downstream readers after 10 seconds. API documentation describes heartbeat, reconnect and timeout behavior.

Validation: real composed-listener RED/GREEN for the 30-second cutoff, shutdown timeout and terminal-cursor hang; real nginx RED/GREEN for slow-client timeout. Direct/proxy regressions cover three heartbeats, cancellation, durable ending replay, shutdown and a 20,000-event slow-reader backlog. Full race suites pass, including PostgreSQL (178s) and composed control plane (470s). Handler/architecture, formatting, vet, lint, builds, docs/OpenAPI, vulnerability/license checks, backend image and secret scan pass. Both independent reviews found no actionable issues and GitHub CI passes. Local make verify still fails on the existing missing web/ frontend packaging step; the full release gate is not claimed green.

Part of issue #48 phase 2. Typed event payloads and serialized schema validation follow within this phase; issue #48 remains incomplete.
