### PR TITLE
Type Investigation events and validate serialized contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ safely.
 
 Investigation events include the Integration display name when a Tool starts and retain
 the canonical answer, up to 4,096 Unicode characters, when the Investigation concludes.
+Current event writers use typed payloads; composed HTTP regressions validate their actual
+serialized envelopes, including nested hypotheses, against OpenAPI.
 
 > OpenCluster is experimental pre-release software. APIs and storage may change without
 > upgrade compatibility until the first stable release; recreate pre-release databases.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1985,7 +1985,11 @@ components:
       properties:
         <<: *investigation-event-properties
         type: { type: string, const: cancelled }
-        payload: { type: object, additionalProperties: false }
+        payload:
+          type: object
+          additionalProperties: false
+          properties:
+            message: { type: string, maxLength: 512 }
     UnknownInvestigationEvent:
       type: object
       additionalProperties: false

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -133,6 +133,10 @@ upstream reads. The supplied nginx configuration uses `proxy_buffering off`,
 Terminal events are `concluded`, `failed`, and `cancelled`. Ignore an unknown future event
 type while retaining its envelope so a newer server remains compatible with an older
 client. The generated stream operation documents every currently shipped event payload.
+Cancellation may include a human-readable `message`. Hypothesis snapshots always use
+arrays for cited Tool Runs, including when none are cited. Invalid hypothesis identities
+and repeated citations are refused before publication. A refused unavailable Tool is
+reported as a failed read without claiming it started against an Integration.
 
 Browse the [API surface](/api-reference/surface) or select an individual generated
 method/path entry in the navigation.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4497,6 +4497,10 @@ components:
         payload:
           type: object
           additionalProperties: false
+          properties:
+            message:
+              type: string
+              maxLength: 512
     UnknownInvestigationEvent:
       type: object
       additionalProperties: false

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ toolchain go1.26.6
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.61.0
+	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/exaring/otelpgx v0.11.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/open-cluster/oc-relay/gen/go v0.4.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
@@ -28,6 +30,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/mod v0.38.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/tools v0.48.0
 	google.golang.org/grpc v1.82.1
@@ -49,7 +52,6 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
-	github.com/coreos/go-oidc/v3 v3.20.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -104,7 +106,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -139,6 +141,8 @@ github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shirou/gopsutil/v4 v4.26.5 h1:RPcBXkpz7kOj9PqGFQOlBPZHsyaPvPVQc098y9RmCNM=
 github.com/shirou/gopsutil/v4 v4.26.5/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -176,7 +176,7 @@ func (r *Agent) Run(
 	}
 	brief := r.conversationBrief(ctx, organization, opened, events)
 	offered := offeredSourcesForConversation(r.Catalog, candidates, origin)
-	r.announce(ctx, events, investigation.EventStarted,
+	r.announce(ctx, events,
 		investigation.StartedPayload(opened, true))
 
 	oriented := r.orientation(ctx, organization, opened, offered, brief)
@@ -268,7 +268,7 @@ func (r *Agent) Run(
 				stoppedBy = investigation.StoppedByContext
 			}
 			if stoppedBy != "" {
-				r.announce(ctx, events, investigation.EventProgress,
+				r.announce(ctx, events,
 					investigation.ProgressPayload(ceilingProgress(stoppedBy)))
 			}
 		}
@@ -415,7 +415,7 @@ func (r *Agent) Run(
 					result.Run.Error = snapshotErr.Error()
 				} else {
 					result.Run.Content = map[string]any{"accepted": true}
-					r.announce(ctx, events, investigation.EventHypothesesUpdated,
+					r.announce(ctx, events,
 						investigation.HypothesesUpdatedPayload(snapshot))
 				}
 				state.carried += runTokens(result.Run)
@@ -441,7 +441,7 @@ func (r *Agent) Run(
 				case state.executedIdentities[identity] != 0:
 					run = suppressedRun(opened, call, len(state.runs)+1,
 						state.executedIdentities[identity])
-					r.announce(ctx, events, investigation.EventProgress,
+					r.announce(ctx, events,
 						investigation.ProgressPayload(
 							"Skipped a repeat of "+offeredName(offered, call.Tool)+
 								"; the earlier read already answers it"))
@@ -451,7 +451,7 @@ func (r *Agent) Run(
 						len(state.runs)+1, fmt.Sprintf(
 							"not executed: the investigation's read budget of %d was exhausted",
 							state.maxRuns))
-					r.announce(ctx, events, investigation.EventProgress,
+					r.announce(ctx, events,
 						investigation.ProgressPayload(
 							"Did not run "+offeredName(offered, call.Tool)+
 								"; the read budget is exhausted"))
@@ -469,7 +469,7 @@ func (r *Agent) Run(
 							investigation.StatusFailed.String(), "")
 						return terminalErr
 					}
-					r.announce(ctx, events, investigation.EventToolCompleted,
+					r.announce(ctx, events,
 						investigation.ToolCompletedPayload(run))
 					r.RuntimeTelemetry.RanTool(run)
 					state.executed++
@@ -558,12 +558,20 @@ func decodeHypothesisSnapshot(
 		if seen[hypothesis.ID] {
 			return nil, fmt.Errorf("hypothesis id %q appears more than once", hypothesis.ID)
 		}
+		if len([]rune(hypothesis.ID)) > 128 {
+			return nil, errors.New("hypothesis id exceeds 128 characters")
+		}
 		seen[hypothesis.ID] = true
 		if !hypothesisStatusAllowed(hypothesis.Status) {
 			return nil, fmt.Errorf("hypothesis %q has invalid status %q", hypothesis.ID,
 				hypothesis.Status)
 		}
+		references := make(map[int]bool, len(hypothesis.RunRefs))
 		for _, run := range hypothesis.RunRefs {
+			if references[run] {
+				return nil, fmt.Errorf("hypothesis %q cites run %d more than once", hypothesis.ID, run)
+			}
+			references[run] = true
 			if run < 1 || run > runs {
 				return nil, fmt.Errorf("hypothesis %q cites run %d, but only %d runs exist",
 					hypothesis.ID, run, runs)
@@ -572,7 +580,7 @@ func decodeHypothesisSnapshot(
 		result = append(result, investigation.HypothesisResult{
 			ID:        boundText(hypothesis.ID, eventTextBound),
 			Statement: boundText(hypothesis.Statement, eventTextBound), Status: hypothesis.Status,
-			Test: boundText(hypothesis.Test, eventTextBound), RunRefs: hypothesis.RunRefs,
+			Test: boundText(hypothesis.Test, eventTextBound), RunRefs: append([]int{}, hypothesis.RunRefs...),
 		})
 	}
 	return result, nil
@@ -607,19 +615,15 @@ func offeredName(offeredSources []offeredSource, tool string) string {
 func (r *Agent) announceToolStarted(
 	ctx context.Context, state *runState, call toolCall, ordinal int,
 ) {
-	integration, name := "", ""
-	if source, _, offered := toolNamed(selections(state.offered), call.Tool); offered {
-		integration = source.integration.ID.String()
-		name = source.integration.Name
+	source, _, offered := toolNamed(selections(state.offered), call.Tool)
+	if !offered {
+		return
 	}
 	payload := investigation.ToolStartedPayload(investigation.ToolRun{
 		Ordinal: ordinal, Tool: call.Tool, Purpose: call.Purpose,
 		HypothesisID: call.HypothesisID, Arguments: call.Arguments,
-	}, integration)
-	if name != "" {
-		payload["integration"] = name
-	}
-	r.announce(ctx, state.events, investigation.EventToolStarted, payload)
+	}, source.integration.ID.String(), source.integration.Name)
+	r.announce(ctx, state.events, payload)
 }
 
 // record writes one run into the provenance, in ordinal order.

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -68,9 +68,7 @@ func (r *records) ConcludeInvestigation(_ context.Context, _ tenancy.Organizatio
 		return r.terminalErr
 	}
 	r.conclusion, r.status, r.stoppedBy, r.usage = conclusion, investigation.StatusConcluded, stoppedBy, usage
-	r.events = append(r.events, investigation.Event{Sequence: int64(len(r.events) + 1), At: time.Now(),
-		Type: investigation.EventConcluded, Payload: investigation.ConcludedPayload(conclusion, stoppedBy)})
-	return nil
+	return r.appendTerminalPayload(investigation.ConcludedPayload(conclusion, stoppedBy))
 }
 func (r *records) FailInvestigation(_ context.Context, _ tenancy.Organization, _ uuid.UUID, _ uuid.UUID, reason string, usage investigation.Usage) error {
 	r.mu.Lock()
@@ -79,8 +77,20 @@ func (r *records) FailInvestigation(_ context.Context, _ tenancy.Organization, _
 		return r.terminalErr
 	}
 	r.status, r.failure, r.usage = investigation.StatusFailed, reason, usage
+	return r.appendTerminalPayload(investigation.FailedPayload(reason))
+}
+
+func (r *records) appendTerminalPayload(payload investigation.EventPayload) error {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		return err
+	}
 	r.events = append(r.events, investigation.Event{Sequence: int64(len(r.events) + 1), At: time.Now(),
-		Type: investigation.EventFailed, Payload: investigation.FailedPayload(reason)})
+		Type: payload.EventType(), Payload: fields})
 	return nil
 }
 func (r *records) TriggerIncident(context.Context, tenancy.Organization, uuid.UUID) (investigation.Trigger, error) {

--- a/internal/investigation/agent/event_contract_test.go
+++ b/internal/investigation/agent/event_contract_test.go
@@ -3,16 +3,13 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
-	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
 	"github.com/open-cluster/oc-control-plane/internal/integrations"
 	"github.com/open-cluster/oc-control-plane/internal/investigation"
-	"gopkg.in/yaml.v3"
 )
 
 func TestRunEmitsDocumentedToolStartedProperties(t *testing.T) {
@@ -37,7 +34,6 @@ func TestRunEmitsDocumentedToolStartedProperties(t *testing.T) {
 			if event.Payload["integration"] != "Production source" {
 				t.Fatal("Tool-started event lost its Integration display name")
 			}
-			assertEventPayloadProperties(t, "ToolStartedInvestigationEvent", event.Payload)
 			return
 		}
 	}
@@ -77,68 +73,10 @@ func TestRunEmitsDocumentedCanonicalAnswerLength(t *testing.T) {
 					if event.Payload["summary"] != store.conclusion.Summary {
 						t.Fatal("concluded event did not retain the canonical answer")
 					}
-					assertEventPayloadProperties(t, "ConcludedInvestigationEvent", event.Payload)
 					return
 				}
 			}
 			t.Fatal("no concluded event emitted")
 		})
-	}
-}
-
-func assertEventPayloadProperties(t *testing.T, name string, payload map[string]any) {
-	t.Helper()
-	contents, err := os.ReadFile("../../../api/openapi.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var document struct {
-		Components struct {
-			Schemas map[string]struct {
-				Properties map[string]struct {
-					AdditionalProperties any      `yaml:"additionalProperties"`
-					Required             []string `yaml:"required"`
-					Properties           map[string]struct {
-						Type      string `yaml:"type"`
-						MinLength int    `yaml:"minLength"`
-						MaxLength int    `yaml:"maxLength"`
-					} `yaml:"properties"`
-				} `yaml:"properties"`
-			} `yaml:"schemas"`
-		} `yaml:"components"`
-	}
-	if err := yaml.Unmarshal(contents, &document); err != nil {
-		t.Fatal(err)
-	}
-	schema := document.Components.Schemas[name].Properties["payload"]
-	if schema.AdditionalProperties != false || len(schema.Properties) == 0 {
-		t.Fatal("expected a declared closed payload schema")
-	}
-	encoded, err := json.Marshal(payload)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var serialized map[string]any
-	if err := json.Unmarshal(encoded, &serialized); err != nil {
-		t.Fatal(err)
-	}
-	for _, required := range schema.Required {
-		if _, present := serialized[required]; !present {
-			t.Errorf("%s omitted required %s", name, required)
-		}
-	}
-	for field, value := range serialized {
-		property, present := schema.Properties[field]
-		if !present {
-			t.Errorf("%s emitted undeclared property %s", name, field)
-			continue
-		}
-		if property.Type == "string" {
-			text, ok := value.(string)
-			length := utf8.RuneCountInString(text)
-			if !ok || length < property.MinLength || (property.MaxLength > 0 && length > property.MaxLength) {
-				t.Errorf("%s.%s violates its declared string bound: length=%d", name, field, length)
-			}
-		}
 	}
 }

--- a/internal/investigation/agent/tools.go
+++ b/internal/investigation/agent/tools.go
@@ -193,11 +193,11 @@ func (r *Agent) persistFailure(
 
 // announce treats progress as best effort. Terminal events commit with the result.
 func (r *Agent) announce(
-	ctx context.Context, events *investigation.EventStream, eventType investigation.EventType, payload map[string]any,
+	ctx context.Context, events *investigation.EventStream, payload investigation.EventPayload,
 ) {
-	if err := events.Emit(ctx, eventType, payload); err != nil {
+	if err := events.Emit(ctx, payload); err != nil {
 		r.Logger.Warn("an investigation event could not be written",
-			slog.String("event", eventType.String()),
+			slog.String("event", payload.EventType().String()),
 			slog.String("error", err.Error()))
 	}
 }

--- a/internal/investigation/agent/tools_test.go
+++ b/internal/investigation/agent/tools_test.go
@@ -79,9 +79,9 @@ func TestAnEventReportsNoWindowForAReadThatDidNotUseOne(t *testing.T) {
 		WindowApplied: false,
 	})
 
-	if _, present := payload["windowFrom"]; present {
+	if payload.WindowFrom != "" {
 		t.Errorf("a listing that filtered by no window reports one: %v",
-			payload["windowFrom"])
+			payload.WindowFrom)
 	}
 }
 
@@ -96,9 +96,9 @@ func TestAnEventReportsTheWindowForAReadThatUsedOne(t *testing.T) {
 		WindowApplied: true,
 	})
 
-	if payload["windowFrom"] != from.Format(time.RFC3339) {
+	if payload.WindowFrom != from.Format(time.RFC3339) {
 		t.Errorf("windowFrom = %v; a windowed read must say what it covered",
-			payload["windowFrom"])
+			payload.WindowFrom)
 	}
 }
 

--- a/internal/investigation/event_payload.go
+++ b/internal/investigation/event_payload.go
@@ -1,0 +1,145 @@
+package investigation
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventPayload ties a current writer's payload to its wire event identity.
+type EventPayload interface {
+	EventType() EventType
+}
+
+type StartedEventPayload struct {
+	Subject     string `json:"subject"`
+	State       string `json:"state"`
+	WindowFrom  string `json:"windowFrom"`
+	WindowUntil string `json:"windowUntil"`
+	Question    string `json:"question,omitempty"`
+	Turn        int    `json:"turn,omitempty"`
+}
+
+func (StartedEventPayload) EventType() EventType { return EventStarted }
+
+func StartedPayload(opened Investigation, executing bool) StartedEventPayload {
+	payload := StartedEventPayload{
+		Subject: bounded(opened.Subject, eventTextBound), State: "waiting",
+		WindowFrom:  opened.WindowFrom.UTC().Format(time.RFC3339),
+		WindowUntil: opened.WindowUntil.UTC().Format(time.RFC3339),
+		Question:    bounded(opened.Question, eventTextBound), Turn: opened.Turn,
+	}
+	if executing {
+		payload.State = "executing"
+	}
+	return payload
+}
+
+type ProgressEventPayload struct {
+	Text string `json:"text"`
+}
+
+func (ProgressEventPayload) EventType() EventType { return EventProgress }
+
+func ProgressPayload(text string) ProgressEventPayload {
+	return ProgressEventPayload{Text: bounded(text, eventTextBound)}
+}
+
+type ToolStartedEventPayload struct {
+	Ordinal       int            `json:"ordinal"`
+	Tool          string         `json:"tool"`
+	IntegrationID string         `json:"integrationId"`
+	Integration   string         `json:"integration,omitempty"`
+	Arguments     map[string]any `json:"arguments"`
+	Purpose       string         `json:"purpose,omitempty"`
+	HypothesisID  string         `json:"hypothesisId,omitempty"`
+}
+
+func (ToolStartedEventPayload) EventType() EventType { return EventToolStarted }
+
+func ToolStartedPayload(run ToolRun, integration, name string) ToolStartedEventPayload {
+	return ToolStartedEventPayload{
+		Ordinal: run.Ordinal, Tool: bounded(run.Tool, eventTextBound), IntegrationID: integration,
+		Integration: bounded(name, eventTextBound), Arguments: run.Arguments,
+		Purpose: bounded(run.Purpose, eventTextBound), HypothesisID: bounded(run.HypothesisID, eventTextBound),
+	}
+}
+
+type ToolCompletedEventPayload struct {
+	Ordinal       int      `json:"ordinal"`
+	Tool          string   `json:"tool"`
+	Outcome       string   `json:"outcome"`
+	DurationMs    int64    `json:"durationMs"`
+	IntegrationID string   `json:"integrationId,omitempty"`
+	Summary       string   `json:"summary,omitempty"`
+	Error         string   `json:"error,omitempty"`
+	Truncated     bool     `json:"truncated,omitempty"`
+	WindowFrom    string   `json:"windowFrom,omitempty"`
+	WindowUntil   string   `json:"windowUntil,omitempty"`
+	Sources       []string `json:"sources,omitempty"`
+}
+
+func (ToolCompletedEventPayload) EventType() EventType { return EventToolCompleted }
+
+func ToolCompletedPayload(run ToolRun) ToolCompletedEventPayload {
+	payload := ToolCompletedEventPayload{
+		Ordinal: run.Ordinal, Tool: bounded(run.Tool, eventTextBound), Outcome: outcomeWord(run.Outcome),
+		DurationMs: run.FinishedAt.Sub(run.StartedAt).Milliseconds(), Summary: bounded(run.Summary, eventTextBound),
+		Error: bounded(run.Error, eventTextBound), Truncated: run.Truncated, Sources: run.Sources,
+	}
+	if run.IntegrationID != uuid.Nil {
+		payload.IntegrationID = run.IntegrationID.String()
+	}
+	if run.WindowApplied {
+		payload.WindowFrom = run.WindowFrom.UTC().Format(time.RFC3339)
+		payload.WindowUntil = run.WindowUntil.UTC().Format(time.RFC3339)
+	}
+	return payload
+}
+
+type HypothesesEventPayload struct {
+	Version    int                `json:"version"`
+	Hypotheses []HypothesisResult `json:"hypotheses"`
+}
+
+func (HypothesesEventPayload) EventType() EventType { return EventHypothesesUpdated }
+
+func HypothesesUpdatedPayload(hypotheses []HypothesisResult) HypothesesEventPayload {
+	return HypothesesEventPayload{Version: EventSchemaVersion, Hypotheses: hypotheses}
+}
+
+type ConcludedEventPayload struct {
+	Status    ConclusionStatus `json:"status"`
+	Findings  int              `json:"findings"`
+	Summary   string           `json:"summary,omitempty"`
+	StoppedBy string           `json:"stoppedBy,omitempty"`
+}
+
+func (ConcludedEventPayload) EventType() EventType { return EventConcluded }
+
+func ConcludedPayload(conclusion Conclusion, stoppedBy string) ConcludedEventPayload {
+	return ConcludedEventPayload{
+		Status: conclusion.Status, Findings: len(conclusion.Findings),
+		Summary: bounded(conclusion.Summary, MaxSummaryLength), StoppedBy: stoppedBy,
+	}
+}
+
+type FailedEventPayload struct {
+	Reason string `json:"reason"`
+}
+
+func (FailedEventPayload) EventType() EventType { return EventFailed }
+
+func FailedPayload(reason string) FailedEventPayload {
+	return FailedEventPayload{Reason: bounded(reason, maxRunErrorLength)}
+}
+
+type CancelledEventPayload struct {
+	Message string `json:"message"`
+}
+
+func (CancelledEventPayload) EventType() EventType { return EventCancelled }
+
+func CancelledPayload() CancelledEventPayload {
+	return CancelledEventPayload{Message: "Investigation cancelled by an operator"}
+}

--- a/internal/investigation/events.go
+++ b/internal/investigation/events.go
@@ -71,8 +71,7 @@ type Event struct {
 	Sequence int64
 	At       time.Time
 	Type     EventType
-	// Payload is the event's own structure. It never carries a credential, a header, a
-	// system prompt or a raw tool result.
+	// Replay stays open to historical and future fields; current writers use EventPayload.
 	Payload map[string]any
 }
 
@@ -142,9 +141,20 @@ func newStream(appendEvent func(
 }
 
 func (s *stream) Emit(
-	ctx context.Context, eventType EventType, payload map[string]any,
+	ctx context.Context, payload EventPayload,
 ) error {
-	return s.emit(ctx, eventType, payload)
+	if s == nil || s.appendEvent == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		return err
+	}
+	return s.emit(ctx, payload.EventType(), fields)
 }
 
 // emit writes one event, returning whatever went wrong so the caller can log it.
@@ -245,141 +255,6 @@ func sortedKeys(payload map[string]any) []string {
 }
 
 const maxPayloadEntries = audit.MaxDetailEntries
-
-// startedPayload opens the stream: what this investigation is about, and whether it is
-// executing or still waiting. The lease is what distinguishes those, and both are
-// `running`, so the first event is where a reader learns which.
-func startedPayload(opened Investigation, executing bool) map[string]any {
-	payload := map[string]any{
-		"subject":     bounded(opened.Subject, eventTextBound),
-		"state":       "waiting",
-		"windowFrom":  opened.WindowFrom.UTC().Format(time.RFC3339),
-		"windowUntil": opened.WindowUntil.UTC().Format(time.RFC3339),
-	}
-	if executing {
-		payload["state"] = "executing"
-	}
-	if opened.Question != "" {
-		payload["question"] = bounded(opened.Question, eventTextBound)
-	}
-	if opened.Turn > 0 {
-		payload["turn"] = opened.Turn
-	}
-	return payload
-}
-
-// toolStartedPayload says which read is about to happen and where it is going. The
-// arguments are the call's own scope, normalized: a person watching wants to know it is
-// reading #deploys and not #random.
-func toolStartedPayload(run ToolRun, integration string) map[string]any {
-	payload := map[string]any{
-		"ordinal":       run.Ordinal,
-		"tool":          bounded(run.Tool, eventTextBound),
-		"integrationId": integration,
-		"arguments":     run.Arguments,
-	}
-	if run.Purpose != "" {
-		payload["purpose"] = bounded(run.Purpose, eventTextBound)
-	}
-	if run.HypothesisID != "" {
-		payload["hypothesisId"] = bounded(run.HypothesisID, eventTextBound)
-	}
-	return payload
-}
-
-// toolCompletedPayload says what came back, in one line, using the provider's OWN summary
-// — the same sentence the provenance records. A failed read is reported as a failure
-// rather than omitted, because a gap in an answer that is explained is a different thing
-// from one that is silent.
-func toolCompletedPayload(run ToolRun) map[string]any {
-	payload := map[string]any{
-		"ordinal":    run.Ordinal,
-		"tool":       bounded(run.Tool, eventTextBound),
-		"outcome":    outcomeWord(run.Outcome),
-		"durationMs": run.FinishedAt.Sub(run.StartedAt).Milliseconds(),
-	}
-	if run.IntegrationID != uuid.Nil {
-		payload["integrationId"] = run.IntegrationID.String()
-	}
-	if run.Summary != "" {
-		payload["summary"] = bounded(run.Summary, eventTextBound)
-	}
-	if run.Error != "" {
-		payload["error"] = bounded(run.Error, eventTextBound)
-	}
-	if run.Truncated {
-		payload["truncated"] = true
-	}
-	// The window the read covered, for the reader who has to tell an empty window from an
-	// empty estate. Absent on a read that covers none, because claiming a window a
-	// repository listing never applied would answer the question wrongly rather than not
-	// at all.
-	if run.WindowApplied {
-		payload["windowFrom"] = run.WindowFrom.UTC().Format(time.RFC3339)
-		payload["windowUntil"] = run.WindowUntil.UTC().Format(time.RFC3339)
-	}
-	if len(run.Sources) > 0 {
-		payload["sources"] = run.Sources
-	}
-	return payload
-}
-
-// progressPayload is a composed sentence and the fact behind it. The text is written here,
-// from what the platform knows; it is never asked for and never received.
-func progressPayload(text string) map[string]any {
-	return map[string]any{"text": bounded(text, eventTextBound)}
-}
-
-func hypothesesUpdatedPayload(hypotheses []HypothesisResult) map[string]any {
-	return map[string]any{
-		"version":    HypothesisSnapshotVersion,
-		"hypotheses": hypotheses,
-	}
-}
-
-// concludedPayload is the ending a reader stops on: the direct answer, how much was
-// established, and the ceiling that forced it if one did.
-func concludedPayload(conclusion Conclusion, stoppedBy string) map[string]any {
-	payload := map[string]any{
-		"status":   conclusion.Status,
-		"findings": len(conclusion.Findings),
-	}
-	if conclusion.Summary != "" {
-		payload["summary"] = bounded(conclusion.Summary, MaxSummaryLength)
-	}
-	if stoppedBy != "" {
-		payload["stoppedBy"] = stoppedBy
-	}
-	return payload
-}
-
-// failedPayload is the other ending. It always states a reason, because a reader left
-// watching a spinner is the failure this exists to prevent.
-func failedPayload(reason string) map[string]any {
-	return map[string]any{"reason": bounded(reason, maxRunErrorLength)}
-}
-
-func StartedPayload(opened Investigation, executing bool) map[string]any {
-	return startedPayload(opened, executing)
-}
-
-func ToolStartedPayload(run ToolRun, integration string) map[string]any {
-	return toolStartedPayload(run, integration)
-}
-
-func ToolCompletedPayload(run ToolRun) map[string]any { return toolCompletedPayload(run) }
-
-func ProgressPayload(text string) map[string]any { return progressPayload(text) }
-
-func HypothesesUpdatedPayload(hypotheses []HypothesisResult) map[string]any {
-	return hypothesesUpdatedPayload(hypotheses)
-}
-
-func ConcludedPayload(conclusion Conclusion, stoppedBy string) map[string]any {
-	return concludedPayload(conclusion, stoppedBy)
-}
-
-func FailedPayload(reason string) map[string]any { return failedPayload(reason) }
 
 const (
 	// eventPollInterval is how often a following connection looks for more. There is no

--- a/internal/investigation/result.go
+++ b/internal/investigation/result.go
@@ -11,10 +11,7 @@ type Agent interface {
 	Run(context.Context, tenancy.Organization, Investigation) error
 }
 
-const (
-	HypothesisSnapshotVersion  = 1
-	MaxHypothesisSnapshotItems = 8
-)
+const MaxHypothesisSnapshotItems = 8
 
 // Conclusion is the versioned, operator-facing result of an investigation.
 type Conclusion struct {

--- a/internal/store/postgres/investigation.go
+++ b/internal/store/postgres/investigation.go
@@ -273,7 +273,7 @@ func (p *Database) ConcludeInvestigation(
 		return fmt.Errorf("encoding conclusion: %w", err)
 	}
 	return p.endInvestigation(ctx, organization, id, token, int16(investigation.StatusConcluded),
-		encoded, stoppedBy, "", usage, investigation.EventConcluded,
+		encoded, stoppedBy, "", usage,
 		investigation.ConcludedPayload(conclusion, stoppedBy))
 }
 
@@ -283,13 +283,17 @@ func (p *Database) FailInvestigation(
 	reason string, usage investigation.Usage,
 ) error {
 	return p.endInvestigation(ctx, organization, id, token, int16(investigation.StatusFailed),
-		[]byte("{}"), "", reason, usage, investigation.EventFailed, investigation.FailedPayload(reason))
+		[]byte("{}"), "", reason, usage, investigation.FailedPayload(reason))
 }
 
 // CancelInvestigation ends active work and records the operator action atomically.
 func (p *Database) CancelInvestigation(
 	ctx context.Context, principal authz.Principal, organization tenancy.Organization, id uuid.UUID,
 ) (investigation.Investigation, error) {
+	payload, err := json.Marshal(investigation.CancelledPayload())
+	if err != nil {
+		return investigation.Investigation{}, err
+	}
 	return audited(ctx, p, principal, organization, audit.ActionInvestigationCancelled,
 		func(ctx context.Context, transaction pgx.Tx) (
 			investigation.Investigation, audit.Target, audit.Detail, error,
@@ -337,10 +341,10 @@ func (p *Database) CancelInvestigation(
 				INSERT INTO investigation_event
 				    (investigation_id, org_id, sequence, at, type, payload)
 				SELECT $1, $2, coalesce(max(sequence), 0) + 1, now(), $3,
-				       jsonb_build_object('message', 'Investigation cancelled by an operator')
+				       $4
 				  FROM investigation_event
 				 WHERE investigation_id = $1 AND org_id = $2`,
-				id, organization.String(), int16(investigation.EventCancelled)); err != nil {
+				id, organization.String(), int16(investigation.EventCancelled), payload); err != nil {
 				return investigation.Investigation{}, audit.Target{}, nil,
 					fmt.Errorf("recording an investigation cancellation event: %w", err)
 			}
@@ -354,7 +358,7 @@ func (p *Database) CancelInvestigation(
 func (p *Database) endInvestigation(
 	ctx context.Context, organization tenancy.Organization, id uuid.UUID, token uuid.UUID,
 	status int16, conclusion []byte, stoppedBy, reason string,
-	usage investigation.Usage, eventType investigation.EventType, payload map[string]any,
+	usage investigation.Usage, payload investigation.EventPayload,
 ) error {
 	pool, err := p.Pool(organization)
 	if err != nil {
@@ -402,7 +406,7 @@ func (p *Database) endInvestigation(
 		SELECT $1, $2, coalesce(max(sequence), 0) + 1, $3, $4
 		  FROM investigation_event
 		 WHERE investigation_id = $1 AND org_id = $2`,
-		id, organization.String(), int16(eventType), encodedPayload); err != nil {
+		id, organization.String(), int16(payload.EventType()), encodedPayload); err != nil {
 		return fmt.Errorf("recording terminal event: %w", err)
 	}
 	return transaction.Commit(ctx)

--- a/internal/store/postgres/investigation_lease.go
+++ b/internal/store/postgres/investigation_lease.go
@@ -173,7 +173,7 @@ func recoverStaleIn(
 		return 0, fmt.Errorf("failing lapsed investigations: %w", err)
 	}
 
-	payload, err := json.Marshal(map[string]any{"reason": reason})
+	payload, err := json.Marshal(investigation.FailedPayload(reason))
 	if err != nil {
 		return 0, fmt.Errorf("encoding a recovery reason: %w", err)
 	}

--- a/internal/store/postgres/investigation_stream_test.go
+++ b/internal/store/postgres/investigation_stream_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestFailedEventWritePreservesStreamStateForRetry(t *testing.T) {
-	for _, eventType := range []investigation.EventType{investigation.EventProgress, investigation.EventFailed} {
+	for _, payload := range []investigation.EventPayload{investigation.ProgressPayload("reading"), investigation.FailedPayload("failed")} {
+		eventType := payload.EventType()
 		t.Run(eventType.String(), func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -27,13 +28,13 @@ func TestFailedEventWritePreservesStreamStateForRetry(t *testing.T) {
 			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event ADD CONSTRAINT reject_stream_test CHECK (type NOT IN (2, 7))`); err != nil {
 				t.Fatal(err)
 			}
-			if err = stream.Emit(ctx, eventType, nil); err == nil {
+			if err = stream.Emit(ctx, payload); err == nil {
 				t.Fatal("event write failure was swallowed")
 			}
 			if _, err = pool.Exec(ctx, `ALTER TABLE investigation_event DROP CONSTRAINT reject_stream_test`); err != nil {
 				t.Fatal(err)
 			}
-			if err = stream.Emit(ctx, eventType, nil); err != nil {
+			if err = stream.Emit(ctx, payload); err != nil {
 				t.Fatal(err)
 			}
 			events, err := database.Events(ctx, org, id, 0, 0)

--- a/internal/store/postgres/investigation_terminal_race_test.go
+++ b/internal/store/postgres/investigation_terminal_race_test.go
@@ -1,0 +1,68 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestCancellationRacesCompletionAndStaleOwnership(t *testing.T) {
+	database, org := migratedDatabase(t)
+	ctx := context.Background()
+	for range 10 {
+		id := aTurn(t, database, org)
+		token := claimToken(t, database, org, id)
+		start := make(chan struct{})
+		finished := make(chan error, 2)
+		stale := make(chan error, 1)
+		go func() {
+			<-start
+			finished <- database.ConcludeInvestigation(ctx, org, id, token,
+				conclusionSaying("committed answer"), "", investigation.Usage{})
+		}()
+		principal := ownerOf(t, org)
+		go func() {
+			<-start
+			_, err := database.CancelInvestigation(ctx, principal, org, id)
+			finished <- err
+		}()
+		go func() {
+			<-start
+			stale <- database.FailInvestigation(ctx, org, id, uuid.New(), "stale failure", investigation.Usage{})
+		}()
+		close(start)
+		winners := 0
+		for range 2 {
+			err := <-finished
+			if err == nil {
+				winners++
+			} else if !errors.Is(err, investigation.ErrUnknown) && !errors.Is(err, investigation.ErrAlreadyEnded) {
+				t.Fatal(err)
+			}
+		}
+		if err := <-stale; !errors.Is(err, investigation.ErrUnknown) {
+			t.Fatalf("stale writer result = %v", err)
+		}
+		if winners != 1 {
+			t.Fatalf("terminal winners=%d, want one", winners)
+		}
+		events, err := database.Events(ctx, org, id, 0, 0)
+		if err != nil || len(events) != 1 {
+			t.Fatalf("events=%+v, error=%v", events, err)
+		}
+		result, err := database.Investigation(ctx, org, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status == investigation.StatusConcluded {
+			if events[0].Type != investigation.EventConcluded || events[0].Payload["summary"] != result.Conclusion.Summary {
+				t.Fatal("conclusion and replay disagree")
+			}
+		} else if result.Status != investigation.StatusCancelled || events[0].Type != investigation.EventCancelled {
+			t.Fatal("cancellation and replay disagree")
+		}
+	}
+}

--- a/test/controlplane/completion_process_test.go
+++ b/test/controlplane/completion_process_test.go
@@ -1,0 +1,188 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+)
+
+const completionProcessConfig = "OC_TEST_COMPLETION_CONFIG_FILE"
+
+func TestCompletionProcessHelper(t *testing.T) {
+	path := os.Getenv(completionProcessConfig)
+	if path == "" {
+		return
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg config.Config
+	if err := json.Unmarshal(contents, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Run(context.Background(), cfg, os.Stderr, app.Options{Model: concludingModel{}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startCompletionProcess(t *testing.T, cfg config.Config) (string, func()) {
+	t.Helper()
+	cfg.HTTPAddress = freeAddress(t)
+	cfg.OperatorPublicURL = "http://" + cfg.HTTPAddress
+	cfg.OperatorTokenDigest = nil
+	cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+	contents, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "process.json")
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestCompletionProcessHelper$")
+	command.Env = append(os.Environ(), completionProcessConfig+"="+path)
+	logs := &syncBuffer{}
+	command.Stdout, command.Stderr = logs, logs
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	var once sync.Once
+	kill := func() { once.Do(func() { _ = command.Process.Kill(); _ = command.Wait() }) }
+	t.Cleanup(kill)
+	client := &http.Client{Timeout: time.Second}
+	for deadline := time.Now().Add(20 * time.Second); time.Now().Before(deadline); {
+		response, err := client.Get(cfg.OperatorPublicURL + "/healthz")
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return cfg.HTTPAddress, kill
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("completion process did not listen: %s", logs.String())
+	return "", kill
+}
+
+func TestCompletionSurvivesProcessInterruption(t *testing.T) {
+	var cfg config.Config
+	address := freeAddress(t)
+	running := startControlPlaneRunning(t, func(value *config.Config) {
+		value.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		value.OperatorTokenDigest = digest[:]
+		cfg = *value
+	}, app.Options{})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	plane.shutdown()
+	if plane.exitErr != nil {
+		t.Fatal(plane.exitErr)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	database, err := pgx.Connect(ctx, cfg.DatabaseDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close(context.Background()) }()
+	_, err = database.Exec(ctx, `
+		CREATE FUNCTION pause_completion() RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			IF NEW.type = 6 THEN PERFORM pg_advisory_xact_lock(4867); END IF;
+			RETURN NEW;
+		END $$;
+		CREATE TRIGGER pause_completion BEFORE INSERT ON investigation_event
+		FOR EACH ROW EXECUTE FUNCTION pause_completion();
+		SELECT pg_advisory_lock(4867)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kill func()
+	plane.operator, kill = startCompletionProcess(t, cfg)
+	_, interrupted := plane.openConversation(t, "interrupted completion", "investigate checkout")
+	paused := false
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); {
+		if err := database.QueryRow(ctx, `SELECT EXISTS (
+			SELECT 1 FROM pg_stat_activity WHERE datname = current_database() AND wait_event = 'advisory')`).Scan(&paused); err != nil {
+			t.Fatal(err)
+		}
+		if paused {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if !paused {
+		t.Fatal("completion never reached the paused terminal transaction")
+	}
+	kill()
+	if _, err := database.Exec(ctx, `SELECT pg_advisory_unlock(4867);
+		DROP TRIGGER pause_completion ON investigation_event; DROP FUNCTION pause_completion()`); err != nil {
+		t.Fatal(err)
+	}
+	var status int
+	var noEnding, noResult bool
+	if err := database.QueryRow(ctx, `SELECT status, concluded_at IS NULL, conclusion = '{}'::jsonb
+		FROM investigation WHERE investigation_id = $1 AND org_id = $2`, interrupted, surfaceOrg).
+		Scan(&status, &noEnding, &noResult); err != nil {
+		t.Fatal(err)
+	}
+	if status != 1 || !noEnding || !noResult {
+		t.Fatal("interrupted transaction left a partial outcome")
+	}
+	if _, err := database.Exec(ctx, `UPDATE investigation SET lease_expires_at = clock_timestamp() - interval '1 second'
+		WHERE investigation_id = $1 AND org_id = $2`, interrupted, surfaceOrg); err != nil {
+		t.Fatal(err)
+	}
+	plane.operator, kill = startCompletionProcess(t, cfg)
+	response := openEventStream(t, plane, interrupted, "")
+	_, err = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if err != nil {
+		t.Fatalf("waiting for the recovery sweep: %v", err)
+	}
+	assertOneEnding(t, plane, interrupted, "failed")
+	_, completed := plane.openConversation(t, "committed completion", "investigate checkout")
+	before := plane.awaitInvestigation(t, completed)
+	kill()
+	plane.operator, _ = startCompletionProcess(t, cfg)
+	code, after := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+completed, nil)
+	if code != http.StatusOK || before != after {
+		t.Fatalf("restart changed the committed outcome: status=%d, before=%s, after=%s", code, before, after)
+	}
+	assertOneEnding(t, plane, completed, "concluded")
+}
+
+func assertOneEnding(t *testing.T, plane *integrationPlane, turn, ending string) {
+	t.Helper()
+	status, body := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+turn+"/events", nil)
+	if status != http.StatusOK {
+		t.Fatalf("replay = %d: %s", status, body)
+	}
+	endings := 0
+	for _, event := range assertSerializedEvents(t, body) {
+		kind := event["type"]
+		if kind == "concluded" || kind == "failed" || kind == "cancelled" {
+			endings++
+			if kind != ending {
+				t.Errorf("ending=%v, want %s", kind, ending)
+			}
+		}
+	}
+	if endings != 1 {
+		t.Fatalf("terminal events=%d, want one", endings)
+	}
+}

--- a/test/controlplane/event_schema_test.go
+++ b/test/controlplane/event_schema_test.go
@@ -1,0 +1,107 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+	modelagent "github.com/open-cluster/oc-control-plane/internal/investigation/agent"
+)
+
+type failedEventModel struct{}
+
+func (failedEventModel) Complete(context.Context, modelagent.Prompt) (modelagent.Completion, error) {
+	return modelagent.Completion{}, errors.New("provider unavailable")
+}
+
+func TestFailedEventMatchesSerializedSchema(t *testing.T) {
+	address := freeAddress(t)
+	running := startControlPlaneRunning(t, func(cfg *config.Config) {
+		cfg.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		cfg.OperatorTokenDigest = digest[:]
+		cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+	}, app.Options{Model: failedEventModel{}})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	_, turn := plane.openConversation(t, "failure schema", "investigate checkout")
+	plane.awaitInvestigation(t, turn)
+	status, body := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+turn+"/events", nil)
+	if status != http.StatusOK {
+		t.Fatalf("replay = %d: %s", status, body)
+	}
+	events := assertSerializedEvents(t, body)
+	if events[len(events)-1]["type"] != "failed" {
+		t.Fatal("no failed ending validated")
+	}
+}
+
+func TestCancelledEventMatchesSerializedSchema(t *testing.T) {
+	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	_, turn := plane.openConversation(t, "cancel schema", "investigate checkout")
+	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations/"+turn+"/cancel", nil)
+	if status != http.StatusOK {
+		t.Fatalf("cancel = %d: %s", status, body)
+	}
+	status, body = plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+turn+"/events", nil)
+	if status != http.StatusOK {
+		t.Fatalf("replay = %d: %s", status, body)
+	}
+	assertSerializedEvents(t, body)
+}
+
+func assertSerializedEvents(t *testing.T, stream string) []map[string]any {
+	t.Helper()
+	schema := eventSchema(t)
+	var events []map[string]any
+	for _, line := range strings.Split(stream, "\n") {
+		data, present := strings.CutPrefix(line, "data: ")
+		if !present {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			t.Fatal(err)
+		}
+		if err := schema.Validate(event); err != nil {
+			t.Errorf("serialized %v event violates OpenAPI: %v", event["type"], err)
+		}
+		events = append(events, event)
+	}
+	if len(events) == 0 {
+		t.Fatal("no serialized events were validated")
+	}
+	return events
+}
+
+func eventSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	contents, err := os.ReadFile("../../api/openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := yaml.Unmarshal(contents, &document); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.AssertFormat()
+	if err := compiler.AddResource("openapi.json", document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("openapi.json#/components/schemas/InvestigationEvent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}

--- a/test/controlplane/hypothesis_event_test.go
+++ b/test/controlplane/hypothesis_event_test.go
@@ -1,0 +1,121 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/open-cluster/oc-control-plane/internal/app"
+	"github.com/open-cluster/oc-control-plane/internal/config"
+	modelagent "github.com/open-cluster/oc-control-plane/internal/investigation/agent"
+)
+
+type hypothesisEventModel struct {
+	calls         int
+	tool          string
+	hypothesisID  string
+	duplicateRefs bool
+}
+
+func (m *hypothesisEventModel) Complete(ctx context.Context, prompt modelagent.Prompt) (modelagent.Completion, error) {
+	m.calls++
+	if m.calls == 1 {
+		id := m.hypothesisID
+		if id == "" {
+			id = "checkout"
+		}
+		return modelagent.Completion{Stop: modelagent.StopToolUse, ToolCalls: []modelagent.CompletionCall{{
+			ID: "hypothesis", Name: modelagent.UpdateHypothesesToolName,
+			Arguments: json.RawMessage(`{"hypotheses":[{"id":"` + id + `","statement":"Checkout may be overloaded","status":"exploring","test":"Read workload metrics"}]}`),
+		}}}, nil
+	}
+	if m.calls == 3 && m.duplicateRefs {
+		return modelagent.Completion{Stop: modelagent.StopToolUse, ToolCalls: []modelagent.CompletionCall{{
+			ID: "duplicate", Name: modelagent.UpdateHypothesesToolName,
+			Arguments: json.RawMessage(`{"hypotheses":[{"id":"checkout","statement":"Checkout may be overloaded","status":"exploring","test":"Read workload metrics","run_refs":[1,1]}]}`),
+		}}}, nil
+	}
+	if m.calls == 2 || m.calls == 3 {
+		return modelagent.Completion{Stop: modelagent.StopToolUse, ToolCalls: []modelagent.CompletionCall{{
+			ID: "channels", Name: m.tool,
+			Arguments: json.RawMessage(`{"purpose":"Find the incident channel","input":{}}`),
+		}}}, nil
+	}
+	completion, err := (concludingModel{}).Complete(ctx, prompt)
+	if err != nil {
+		return completion, err
+	}
+	var document map[string]any
+	if err := json.Unmarshal(completion.ToolCalls[0].Arguments, &document); err != nil {
+		return modelagent.Completion{}, err
+	}
+	document["summary"] = strings.Repeat("界", 4096)
+	completion.ToolCalls[0].Arguments, err = json.Marshal(document)
+	return completion, err
+}
+
+func TestHypothesisAndAnswerEventsMatchSerializedSchema(t *testing.T) {
+	assertModelEventSchema(t, &hypothesisEventModel{tool: "slack.list_channels"},
+		[]string{"started", "hypotheses_updated", "tool_started", "tool_completed", "progress", "concluded"})
+}
+
+func TestUnavailableToolEventsMatchSerializedSchema(t *testing.T) {
+	assertModelEventSchema(t, &hypothesisEventModel{tool: "unavailable.read"},
+		[]string{"started", "hypotheses_updated", "tool_completed", "progress", "concluded"})
+}
+
+func TestOversizedHypothesisIdentityIsNotPublished(t *testing.T) {
+	assertModelEventSchema(t, &hypothesisEventModel{tool: "slack.list_channels", hypothesisID: strings.Repeat("h", 129)},
+		[]string{"started", "tool_started", "tool_completed", "progress", "concluded"})
+}
+
+func TestDuplicateHypothesisReferencesAreNotPublished(t *testing.T) {
+	assertModelEventSchema(t, &hypothesisEventModel{tool: "slack.list_channels", duplicateRefs: true},
+		[]string{"started", "hypotheses_updated", "tool_started", "tool_completed", "concluded"})
+}
+
+func assertModelEventSchema(t *testing.T, model *hypothesisEventModel, want []string) {
+	t.Helper()
+	vendor := newVendorFake(t, "xoxb-good-token-1234")
+	vendor.channels = `{"ok":true,"channels":[{"id":"C0INCIDENT","name":"incidents"}]}`
+	address := freeAddress(t)
+	running := startControlPlaneRunning(t, func(cfg *config.Config) {
+		cfg.HTTPAddress = address
+		digest := sha256.Sum256([]byte(surfaceToken))
+		cfg.OperatorTokenDigest = digest[:]
+		cfg.ModelProvider, cfg.ModelName, cfg.ModelKey = "zai", "glm-4.7", "scripted-model-key"
+	}, app.Options{Model: model, SlackAPIURL: vendor.URL})
+	plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
+	if status, body := plane.createSlack(t, "Operator testimony", "xoxb-good-token-1234"); status != http.StatusCreated {
+		t.Fatalf("create Slack = %d: %s", status, body)
+	}
+	_, turn := plane.openConversation(t, "hypothesis schema", "investigate checkout")
+	result := plane.awaitInvestigation(t, turn)
+	var final struct {
+		Summary string `json:"summary"`
+	}
+	decodeInto(t, result, &final)
+	status, body := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+turn+"/events", nil)
+	if status != http.StatusOK {
+		t.Fatalf("replay = %d: %s", status, body)
+	}
+	seen := make(map[string]bool)
+	for _, event := range assertSerializedEvents(t, body) {
+		kind := event["type"].(string)
+		seen[kind] = true
+		if kind == "concluded" && event["payload"].(map[string]any)["summary"] != final.Summary {
+			t.Fatal("event answer differs from its canonical result")
+		}
+	}
+	if len(seen) != len(want) {
+		t.Errorf("event types = %v, want %v", seen, want)
+	}
+	for _, kind := range want {
+		if !seen[kind] {
+			t.Errorf("no %s event validated", kind)
+		}
+	}
+}


### PR DESCRIPTION
Investigation writers now construct typed payloads tied to their event identity. Terminal transitions, recovery and cancellation use the same payload constructors. Decoded replay maps retain historical/future fields for existing consumers. Forwarding-only payload functions and the independent hypothesis version constant are removed; the existing wire version remains tied to EventSchemaVersion.

Actual SSE envelopes are validated against OpenAPI with a full JSON Schema validator, replacing the partial handwritten property checker. Regressions exposed and fix an undeclared cancellation message, null hypothesis references, oversized hypothesis IDs, duplicate citations and a Tool-started event for unavailable capabilities. Canonical 4,096-character Unicode answers remain intact. Invalid snapshots are refused before publication; an unavailable Tool retains its failed outcome without claiming execution.

Validation: real PostgreSQL/composed HTTP/model-loop/Slack HTTP regressions cover all eight active event types, nested constraints, cancellation, provider failure, Unicode answers, progress and retryable event persistence. Focused tests and both independent reviews pass. Final-head CI passed in 8m19s. Full local application/PostgreSQL/composed HTTP/E2E race suites, lint, architecture, documentation, vulnerability call-path scan, license checks, Helm and backend image build passed. The added process/race tests also passed separately with the race detector and in final-head CI. Full make verify is not green: the existing frontend Dockerfile references missing web/. That remains a separate release blocker.

Final durability evidence kills a test-owned application process while terminal insertion is blocked after the outcome update, verifies rollback, then restarts on the retained database and waits for the real recovery sweep to replay one failed ending. A separate kill after acknowledged completion preserves the identical result and one concluded ending on restart. A PostgreSQL race between cancellation, completion and a stale token yields exactly one matching outcome/event. Both tests pass with the race detector.

This is the final planned slice of issue #48 phase 2, following merged PRs #65 and #66 and the earlier queue/terminal PRs. Issue #48 remains open for the other phases.
