### PR TITLE
Fence Slack delivery and restore timely flushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Each claim has a unique token fencing progress, Tool Runs and terminal writes. P
 allocates replay sequences under the same Investigation lock used by terminal transitions.
 Stop old control-plane replicas before upgrading to claim-token fencing; interrupted
 Investigations are recovered as failed rather than resumed by an older worker.
+Slack delivery also uses unique claim tokens. Normal flush scheduling releases ownership
+independently of crash recovery; provider acceptance remains an
+[at-least-once boundary](./docs/integrations/collaboration/slack.mdx#reply-delivery).
+Stop old replicas before upgrading Slack delivery fencing as well.
 Conversation detail includes the first 50 turns; use `turnsNext` with the turns endpoint
 to continue reading in order, with up to 200 turns per page.
 

--- a/docs/integrations/collaboration/slack.mdx
+++ b/docs/integrations/collaboration/slack.mdx
@@ -22,6 +22,19 @@ integration. If OpenCluster cannot verify that origin, the investigation stops.
 Unavailable previous conversation history limits continuity explicitly; it does not
 expand access to other Slack conversations.
 
+## Reply delivery
+
+Completed reads and answers are sent in batches. Normal passes become eligible again
+after about one second, including passes with nothing ready to send. Temporary failures
+use bounded retry backoff; a failed Slack delivery does not change the investigation's
+result, which remains available in OpenCluster.
+
+Delivery is at least once. Once a reply's identity is saved, subsequent updates reuse
+that message. If Slack accepts a message before OpenCluster saves its identity, a crash
+or lost connection can leave an extra message on retry. A native stream append accepted
+before progress is saved can likewise appear twice. Retries of an acknowledged terminal
+answer only finish closing its stream; they do not append that answer again.
+
 ## Prerequisites
 
 - The **Admin** role in OpenCluster.

--- a/internal/integrations/slack/client_writes.go
+++ b/internal/integrations/slack/client_writes.go
@@ -67,12 +67,8 @@ type Stream struct {
 // Held reports whether this value names a visible message at all.
 func (s Stream) Held() bool { return s.TS != "" }
 
-// StartStream opens the turn's one visible message, EMPTY.
-//
-// Empty on purpose. The caller records the message's identity before any content is sent, so a
-// process that dies immediately afterwards resumes into the message it already opened rather
-// than opening a second one — and an opening that carried content would put that content
-// outside the identity's protection.
+// StartStream opens an empty reply. Once its identity is saved, retries reuse it;
+// interruption before that save can leave an extra visible message.
 func (c *Client) StartStream(ctx context.Context, token, channel, thread string) (Stream, error) {
 	streamed, err := c.write(ctx, token, methodStartStream, url.Values{
 		"channel":   {channel},
@@ -85,7 +81,7 @@ func (c *Client) StartStream(ctx context.Context, token, channel, thread string)
 		return Stream{}, err
 	}
 
-	// The fallback. One placeholder, posted once, edited in place from here on.
+	// A saved placeholder is edited in place on subsequent passes.
 	posted, err := c.write(ctx, token, methodPostMessage, url.Values{
 		"channel":   {channel},
 		"thread_ts": {thread},
@@ -139,7 +135,8 @@ func (c *Client) StopStream(ctx context.Context, token string, stream Stream) er
 		"channel": {stream.Channel},
 		"ts":      {stream.TS},
 	})
-	if err != nil && isUnavailable(err) {
+	var refusal *APIError
+	if isUnavailable(err) || (errors.As(err, &refusal) && refusal.Code == "message_not_in_streaming_state") {
 		return nil
 	}
 	return err

--- a/internal/integrations/slack/client_writes_test.go
+++ b/internal/integrations/slack/client_writes_test.go
@@ -1,0 +1,22 @@
+package slack
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStoppingAnAlreadyClosedStreamSucceeds(t *testing.T) {
+	t.Parallel()
+	vendor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":false,"error":"message_not_in_streaming_state"}`)
+	}))
+	defer vendor.Close()
+	err := NewClient(vendor.URL).StopStream(context.Background(), "fixture", Stream{Channel: "C1", TS: "1700000100.1", Native: true})
+	if err != nil {
+		t.Fatalf("already closed stream was treated as a delivery failure: %v", err)
+	}
+}

--- a/internal/integrations/slack/worker.go
+++ b/internal/integrations/slack/worker.go
@@ -176,6 +176,11 @@ func (w Worker) pass(ctx context.Context, batch int) bool {
 		if w.answer(attempt, reply) {
 			worked = true
 		}
+		if errors.Is(attempt.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			settlement, stop := context.WithDeadline(ctx, reply.LeaseExpiresAt)
+			w.retry(settlement, reply, "slack delivery exceeded its attempt deadline")
+			stop()
+		}
 		cancel()
 	}
 	return worked

--- a/internal/integrations/slack/worker.go
+++ b/internal/integrations/slack/worker.go
@@ -17,21 +17,8 @@ import (
 	"github.com/open-cluster/oc-control-plane/internal/secrets"
 )
 
-// ANSWERING BACK IN THE THREAD.
-//
-// One visible message per turn, driven from the investigation's PERSISTED event stream by a
-// cursor of its own. That is what makes every hard case ordinary: a transient failure retries
-// and appends what was missed rather than reposting what was seen, and a worker killed
-// mid-stream resumes from the cursor instead of starting the answer again.
-//
-// A REPLY FAILURE IS NEVER AN INVESTIGATION FAILURE. They are related concerns and not the
-// same one. The investigation concludes or fails on its own terms and its record stays complete
-// and readable in the console whatever Slack did — a chat outage must not be able to cancel or
-// corrupt the work behind it.
-//
-// SLACK IS NEVER CALLED PER TOKEN. Text is coalesced and flushed on a size-or-interval
-// boundary chosen to sit well inside the published rate tier. A worker that called Slack for
-// every delta would be rate-limited into failure by its own enthusiasm.
+// Delivery has its own cursor and outcome. Slack acceptance and local persistence
+// are separate: interruption between them can repeat a message or native append.
 
 // The flush boundary. Whichever comes first: enough text to be worth a call, or enough time
 // that a reader would think nothing was happening.
@@ -52,9 +39,11 @@ const (
 
 // Reply is one investigation's answer on its way into one thread.
 type Reply struct {
-	Investigation uuid.UUID
-	Organization  tenancy.Organization
-	Integration   uuid.UUID
+	Investigation  uuid.UUID
+	ClaimToken     uuid.UUID
+	LeaseExpiresAt time.Time
+	Organization   tenancy.Organization
+	Integration    uuid.UUID
 	// Conversation is the thread's conversation. The reply is written into the thread and
 	// the conversation is what holds who said what in it.
 	Conversation uuid.UUID
@@ -76,23 +65,25 @@ type Progress struct {
 	Sequence int64
 }
 
+var ErrReplyClaimLost = errors.New("slack reply claim lost")
+
 // Replies is what the worker needs from durable state. It is declared here because the
 // collaboration delivery owns its vocabulary and persistence depends on it.
 type Replies interface {
-	// ClaimSlackReplies leases the replies that are due, so two workers cannot write into
-	// one visible message.
+	// ClaimSlackReplies assigns unique ownership to each due reply.
 	ClaimSlackReplies(ctx context.Context, limit int, lease time.Duration) ([]Reply, error)
 	// AdvanceSlackReply records what one pass established: the visible message's identity
 	// once it exists, and how far the cursor has moved. It only ever moves forward.
-	AdvanceSlackReply(ctx context.Context, org tenancy.Organization, investigation uuid.UUID,
+	AdvanceSlackReply(ctx context.Context, org tenancy.Organization, investigation, owner uuid.UUID,
 		made Progress) error
 	// CompleteSlackReply marks one answered. Nothing claims it again.
 	CompleteSlackReply(ctx context.Context, org tenancy.Organization,
-		investigation uuid.UUID) error
+		investigation, owner uuid.UUID) error
 	// RetrySlackReply schedules another attempt, or gives up when there is no attempt left
 	// worth making. The note is this build's own words.
-	RetrySlackReply(ctx context.Context, org tenancy.Organization, investigation uuid.UUID,
+	RetrySlackReply(ctx context.Context, org tenancy.Organization, investigation, owner uuid.UUID,
 		at time.Time, note string, giveUp bool) error
+	ReleaseSlackReply(ctx context.Context, org tenancy.Organization, investigation, owner uuid.UUID, at time.Time) error
 	// RecordCollaborationWrite puts one reply into a customer's workspace on the audit
 	// record. It is the only thing this product writes into a system it does not own, and
 	// "what did OpenCluster say in our Slack" has to be answerable.
@@ -164,23 +155,28 @@ func (w Worker) Run(ctx context.Context) {
 
 // pass takes one batch and reports whether anything moved.
 func (w Worker) pass(ctx context.Context, batch int) bool {
-	claimed, err := w.Replies.ClaimSlackReplies(ctx, batch, leaseDuration)
-	if err != nil {
-		if ctx.Err() == nil {
-			w.Logger.ErrorContext(ctx, "claiming slack replies failed",
-				slog.String("error", err.Error()))
-		}
-		return false
-	}
-
 	worked := false
-	for _, reply := range claimed {
+	for range batch {
+		claimed, err := w.Replies.ClaimSlackReplies(ctx, 1, leaseDuration)
+		if err != nil {
+			if ctx.Err() == nil {
+				w.Logger.ErrorContext(ctx, "claiming slack replies failed",
+					slog.String("error", err.Error()))
+			}
+			return worked
+		}
+		if len(claimed) == 0 {
+			return worked
+		}
+		reply := claimed[0]
 		if ctx.Err() != nil {
 			return worked
 		}
-		if w.answer(ctx, reply) {
+		attempt, cancel := context.WithDeadline(ctx, reply.LeaseExpiresAt.Add(-time.Second))
+		if w.answer(attempt, reply) {
 			worked = true
 		}
+		cancel()
 	}
 	return worked
 }
@@ -200,6 +196,18 @@ func (w Worker) answer(ctx context.Context, reply Reply) bool {
 		return false
 	}
 	if len(events) == 0 {
+		if reply.LastSequence > 0 && reply.Stream.Held() {
+			last, readErr := w.Replies.Events(ctx, reply.Organization, reply.Investigation, reply.LastSequence-1, 1)
+			if readErr != nil {
+				w.retry(ctx, reply, "the investigation's final event could not be read")
+				return false
+			}
+			if len(last) == 1 && last[0].Sequence == reply.LastSequence && Render(last).Done {
+				w.finish(ctx, token, reply)
+				return true
+			}
+		}
+		w.release(ctx, reply)
 		return false
 	}
 
@@ -214,14 +222,13 @@ func (w Worker) answer(ctx context.Context, reply Reply) bool {
 		//
 		// Never held once the turn is done, and never when there is progress to show —
 		// those are the two things a person watching the thread is waiting to see.
+		w.release(ctx, reply)
 		return false
 	}
 
 	if !reply.Stream.Held() {
-		// The turn's one visible message, opened EMPTY and recorded before any content is
-		// sent. A worker that dies between the two resumes into the message it already
-		// opened; an opening that carried content would put that content outside the
-		// identity's protection, and a crash would repost it.
+		// Save identity before content. Provider acceptance before this save remains
+		// an at-least-once boundary; a database token cannot deduplicate Slack writes.
 		stream, startErr := w.Client.StartStream(ctx, token,
 			reply.Stream.Channel, reply.Stream.Thread)
 		if startErr != nil {
@@ -229,7 +236,7 @@ func (w Worker) answer(ctx context.Context, reply Reply) bool {
 			return false
 		}
 		reply.Stream = stream
-		if err := w.Replies.AdvanceSlackReply(ctx, reply.Organization, reply.Investigation,
+		if err := w.Replies.AdvanceSlackReply(ctx, reply.Organization, reply.Investigation, reply.ClaimToken,
 			Progress{Stream: stream, Sequence: reply.LastSequence}); err != nil {
 			w.Logger.ErrorContext(ctx, "recording a slack reply's message failed",
 				slog.String("error", err.Error()))
@@ -248,7 +255,7 @@ func (w Worker) answer(ctx context.Context, reply Reply) bool {
 		w.retry(ctx, reply, "slack would not take the reply")
 		return false
 	}
-	if err := w.Replies.AdvanceSlackReply(ctx, reply.Organization, reply.Investigation,
+	if err := w.Replies.AdvanceSlackReply(ctx, reply.Organization, reply.Investigation, reply.ClaimToken,
 		Progress{Stream: reply.Stream, Sequence: events[len(events)-1].Sequence}); err != nil {
 		w.Logger.ErrorContext(ctx, "recording slack reply progress failed",
 			slog.String("error", err.Error()))
@@ -256,20 +263,29 @@ func (w Worker) answer(ctx context.Context, reply Reply) bool {
 	}
 
 	if rendered.Done {
-		if err := w.Client.StopStream(ctx, token, reply.Stream); err != nil {
-			// The content is delivered and only the close failed. The answer is visible
-			// either way, and one more attempt at closing costs nothing.
-			w.retry(ctx, reply, "slack would not close the reply")
-			return true
-		}
-		if err := w.Replies.CompleteSlackReply(ctx, reply.Organization,
-			reply.Investigation); err != nil {
-			w.Logger.ErrorContext(ctx, "completing a slack reply failed",
-				slog.String("error", err.Error()))
-		}
-		w.Counters.countReply(ctx, replyAnswered)
+		w.finish(ctx, token, reply)
+	} else {
+		w.release(ctx, reply)
 	}
 	return true
+}
+
+func (w Worker) finish(ctx context.Context, token string, reply Reply) {
+	if err := w.Client.StopStream(ctx, token, reply.Stream); err != nil {
+		w.retry(ctx, reply, "slack would not close the reply")
+		return
+	}
+	if err := w.Replies.CompleteSlackReply(ctx, reply.Organization, reply.Investigation, reply.ClaimToken); err != nil {
+		w.Logger.ErrorContext(ctx, "completing a slack reply failed", slog.String("error", err.Error()))
+		return
+	}
+	w.Counters.countReply(ctx, replyAnswered)
+}
+
+func (w Worker) release(ctx context.Context, reply Reply) {
+	if err := w.Replies.ReleaseSlackReply(ctx, reply.Organization, reply.Investigation, reply.ClaimToken, time.Now().Add(flushInterval)); err != nil && ctx.Err() == nil {
+		w.Logger.ErrorContext(ctx, "releasing a slack reply failed", slog.String("error", err.Error()))
+	}
 }
 
 // send writes this batch into the visible message.
@@ -406,7 +422,7 @@ func (w Worker) audit(ctx context.Context, reply Reply) {
 func (w Worker) retry(ctx context.Context, reply Reply, note string) {
 	giveUp := reply.Attempts+1 >= maxAttempts
 	at := time.Now().Add(backoff(reply.Attempts))
-	if err := w.Replies.RetrySlackReply(ctx, reply.Organization, reply.Investigation,
+	if err := w.Replies.RetrySlackReply(ctx, reply.Organization, reply.Investigation, reply.ClaimToken,
 		at, note, giveUp); err != nil {
 		w.Logger.ErrorContext(ctx, "rescheduling a slack reply failed",
 			slog.String("error", err.Error()))

--- a/internal/integrations/slack/worker_test.go
+++ b/internal/integrations/slack/worker_test.go
@@ -153,11 +153,17 @@ func (d *repliesInMemory) ClaimSlackReplies(
 	if d.completed || d.gaveUp {
 		return nil, nil
 	}
-	return []Reply{d.reply}, nil
+	reply := d.reply
+	reply.LeaseExpiresAt = time.Now().Add(leaseDuration)
+	return []Reply{reply}, nil
+}
+
+func (d *repliesInMemory) ReleaseSlackReply(context.Context, tenancy.Organization, uuid.UUID, uuid.UUID, time.Time) error {
+	return nil
 }
 
 func (d *repliesInMemory) AdvanceSlackReply(
-	_ context.Context, _ tenancy.Organization, _ uuid.UUID, made Progress,
+	_ context.Context, _ tenancy.Organization, _, _ uuid.UUID, made Progress,
 ) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -184,7 +190,7 @@ func (d *repliesInMemory) RecordCollaborationWrite(
 }
 
 func (d *repliesInMemory) CompleteSlackReply(
-	context.Context, tenancy.Organization, uuid.UUID,
+	context.Context, tenancy.Organization, uuid.UUID, uuid.UUID,
 ) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -193,7 +199,7 @@ func (d *repliesInMemory) CompleteSlackReply(
 }
 
 func (d *repliesInMemory) RetrySlackReply(
-	_ context.Context, _ tenancy.Organization, _ uuid.UUID,
+	_ context.Context, _ tenancy.Organization, _, _ uuid.UUID,
 	_ time.Time, note string, giveUp bool,
 ) error {
 	d.mu.Lock()

--- a/internal/store/postgres/migrations/0007_slack_reply_claim.sql
+++ b/internal/store/postgres/migrations/0007_slack_reply_claim.sql
@@ -1,0 +1,6 @@
+ALTER TABLE slack_reply ADD COLUMN lease_owner uuid;
+
+UPDATE slack_reply SET lease_owner = gen_random_uuid() WHERE leased_until IS NOT NULL;
+
+ALTER TABLE slack_reply ADD CONSTRAINT slack_reply_lease_is_whole
+    CHECK ((leased_until IS NULL) = (lease_owner IS NULL));

--- a/internal/store/postgres/slack_acceptance_test.go
+++ b/internal/store/postgres/slack_acceptance_test.go
@@ -1,0 +1,107 @@
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+	"github.com/open-cluster/oc-control-plane/internal/store/postgres"
+)
+
+func TestSlackAcceptanceBeforeIdentityPersistenceIsAtLeastOnce(t *testing.T) {
+	for _, native := range []bool{true, false} {
+		t.Run(fmt.Sprintf("native=%v", native), func(t *testing.T) {
+			t.Parallel()
+			var messages atomic.Int32
+			database, org, id, worker := slackDelivery(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/chat.startStream" && !native {
+					_, _ = io.WriteString(w, `{"ok":false,"error":"unknown_method"}`)
+					return
+				}
+				if r.URL.Path == "/chat.startStream" || r.URL.Path == "/chat.postMessage" {
+					_, _ = fmt.Fprintf(w, `{"ok":true,"ts":"1700000100.%d"}`, messages.Add(1))
+					return
+				}
+				_, _ = io.WriteString(w, `{"ok":true}`)
+			}))
+			ctx := context.Background()
+			if err := database.ConcludeInvestigation(ctx, org, id, claimToken(t, database, org, id), conclusionSaying("durable answer"), "", investigation.Usage{}); err != nil {
+				t.Fatal(err)
+			}
+			pool, err := database.Pool(org)
+			if err != nil {
+				t.Fatal(err)
+			}
+			barrier, err := pool.Acquire(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer barrier.Release()
+			if _, err = barrier.Exec(ctx, `SELECT pg_advisory_lock(4868)`); err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _, _ = barrier.Exec(ctx, `SELECT pg_advisory_unlock(4868)`) }()
+			if _, err = pool.Exec(ctx, `CREATE FUNCTION pause_slack_identity() RETURNS trigger LANGUAGE plpgsql AS $$
+				BEGIN IF OLD.stream_ts = '' AND NEW.stream_ts <> '' THEN PERFORM pg_advisory_xact_lock(4868); END IF; RETURN NEW; END $$;
+				CREATE TRIGGER pause_slack_identity BEFORE UPDATE ON slack_reply FOR EACH ROW EXECUTE FUNCTION pause_slack_identity()`); err != nil {
+				t.Fatal(err)
+			}
+			stop := runSlackWorker(t, worker)
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				var blocked bool
+				if err = pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM pg_stat_activity WHERE datname = current_database() AND wait_event = 'advisory')`).Scan(&blocked); err != nil {
+					t.Fatal(err)
+				}
+				if blocked {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("identity persistence never reached the acceptance barrier")
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+			stop()
+			if messages.Load() != 1 {
+				t.Fatalf("provider accepted %d messages before interruption", messages.Load())
+			}
+			if _, err = barrier.Exec(ctx, `SELECT pg_advisory_unlock(4868)`); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = pool.Exec(ctx, `DROP TRIGGER pause_slack_identity ON slack_reply; DROP FUNCTION pause_slack_identity()`); err != nil {
+				t.Fatal(err)
+			}
+			_, sequence, message, _, found, err := database.SlackReplyState(ctx, org, id)
+			if err != nil || !found || sequence != 0 || message != "" {
+				t.Fatalf("interrupted identity was persisted: %d %q %v %v", sequence, message, found, err)
+			}
+			if _, err = pool.Exec(ctx, `UPDATE slack_reply SET leased_until = now() - interval '1 second' WHERE org_id = $1 AND investigation_id = $2`, org.String(), id); err != nil {
+				t.Fatal(err)
+			}
+			runSlackWorker(t, worker)
+			deadline = time.Now().Add(5 * time.Second)
+			for {
+				status, _, message, _, _, readErr := database.SlackReplyState(ctx, org, id)
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if status == storage.SlackReplyDelivered {
+					if message != "1700000100.2" || messages.Load() != 2 {
+						t.Fatalf("retry identity=%q accepted messages=%d", message, messages.Load())
+					}
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("replacement worker did not finish delivery")
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+		})
+	}
+}

--- a/internal/store/postgres/slack_delivery_test.go
+++ b/internal/store/postgres/slack_delivery_test.go
@@ -146,20 +146,20 @@ func TestSlackNonterminalPassesReleaseRecoveryLease(t *testing.T) {
 				}
 				deadline := time.Now().Add(4 * time.Second)
 				for {
-					var exists bool
-					if err = pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM slack_reply WHERE org_id = $1 AND investigation_id = $2)`, org.String(), id).Scan(&exists); err != nil {
+					var released bool
+					if err = pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM slack_reply
+						WHERE org_id = $1 AND investigation_id = $2 AND status = 1
+						AND lease_owner IS NULL AND leased_until IS NULL AND next_attempt_at > now())`, org.String(), id).Scan(&released); err != nil {
 						t.Fatal(err)
 					}
-					if exists {
+					if released {
 						break
 					}
 					if time.Now().After(deadline) {
-						t.Fatal("worker did not claim delivery")
+						t.Fatal("worker did not release the empty or held pass for its next flush")
 					}
 					time.Sleep(20 * time.Millisecond)
 				}
-				// Let the first bounded pass read its empty or held event page.
-				time.Sleep(100 * time.Millisecond)
 			}
 			if err := database.AppendEvent(ctx, org, id, token, investigation.Event{Type: investigation.EventToolCompleted, Payload: map[string]any{"summary": "next batch"}}); err != nil {
 				t.Fatal(err)

--- a/internal/store/postgres/slack_delivery_test.go
+++ b/internal/store/postgres/slack_delivery_test.go
@@ -1,0 +1,170 @@
+package storage_test
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/integrations"
+	"github.com/open-cluster/oc-control-plane/internal/integrations/slack"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+	"github.com/open-cluster/oc-control-plane/internal/secrets"
+	"github.com/open-cluster/oc-control-plane/internal/store/postgres"
+)
+
+func slackDelivery(t *testing.T, handler http.Handler) (*storage.Database, tenancy.Organization, uuid.UUID, slack.Worker) {
+	t.Helper()
+	database, org := migratedDatabase(t)
+	id, integration := aSlackTurn(t, database, org, "T1", "C1", "1700000000.1")
+	material := make([]byte, seal.KeyLength)
+	if _, err := rand.Read(material); err != nil {
+		t.Fatal(err)
+	}
+	sealer, err := seal.New(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := sealer.Seal("test-slack-credential", integrations.CredentialBinding(integration))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := database.Pool(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(context.Background(), `UPDATE integration SET credential_sealed = $3,
+		credential_fingerprint = 'fixture', credential_created_at = now(), credential_key_id = 'default'
+		WHERE org_id = $1 AND integration_id = $2`, org.String(), integration, sealed); err != nil {
+		t.Fatal(err)
+	}
+	vendor := httptest.NewServer(handler)
+	t.Cleanup(vendor.Close)
+	return database, org, id, slack.Worker{Replies: database, Sealer: sealer, Client: slack.NewClient(vendor.URL),
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), Interval: 20 * time.Millisecond, Batch: 1}
+}
+
+func TestSlackRetriesTerminalCloseAfterCursorAdvanced(t *testing.T) {
+	t.Parallel()
+	var appends, stops atomic.Int32
+	database, org, id, worker := slackDelivery(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/chat.appendStream" {
+			appends.Add(1)
+		}
+		if r.URL.Path == "/chat.stopStream" && stops.Add(1) == 1 {
+			_, _ = io.WriteString(w, `{"ok":false,"error":"temporary_failure"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"ok":true,"ts":"1700000100.1"}`)
+	}))
+	ctx := context.Background()
+	if err := database.ConcludeInvestigation(ctx, org, id, claimToken(t, database, org, id), conclusionSaying("durable answer"), "", investigation.Usage{}); err != nil {
+		t.Fatal(err)
+	}
+	runSlackWorker(t, worker)
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		status, _, _, _, _, err := database.SlackReplyState(ctx, org, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if status == storage.SlackReplyDelivered {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("terminal close did not recover: appends=%d stops=%d", appends.Load(), stops.Load())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if appends.Load() != 1 || stops.Load() != 2 {
+		t.Fatalf("acknowledged content repeated: appends=%d stops=%d", appends.Load(), stops.Load())
+	}
+}
+
+func runSlackWorker(t *testing.T, worker slack.Worker) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); worker.Run(ctx) }()
+	stop := func() { cancel(); <-done }
+	t.Cleanup(stop)
+	return stop
+}
+
+func awaitSlackText(t *testing.T, sent <-chan string, expected string) {
+	t.Helper()
+	select {
+	case text := <-sent:
+		if !strings.Contains(text, expected) {
+			t.Fatalf("Slack text %q lacks %q", text, expected)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatalf("Slack did not receive %q at the flush cadence", expected)
+	}
+}
+
+func TestSlackNonterminalPassesReleaseRecoveryLease(t *testing.T) {
+	for _, initial := range []string{"empty", "held", "progress"} {
+		t.Run(initial, func(t *testing.T) {
+			t.Parallel()
+			sent := make(chan string, 8)
+			database, org, id, worker := slackDelivery(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				if r.URL.Path == "/chat.appendStream" {
+					sent <- r.FormValue("markdown_text")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"ok":true,"ts":"1700000100.1"}`)
+			}))
+			ctx := context.Background()
+			token := claimToken(t, database, org, id)
+			if initial != "empty" {
+				event := investigation.Event{Type: investigation.EventStarted, Payload: map[string]any{}}
+				if initial == "progress" {
+					event = investigation.Event{Type: investigation.EventToolCompleted, Payload: map[string]any{"summary": "first batch"}}
+				}
+				if err := database.AppendEvent(ctx, org, id, token, event); err != nil {
+					t.Fatal(err)
+				}
+			}
+			runSlackWorker(t, worker)
+			if initial == "progress" {
+				awaitSlackText(t, sent, "first batch")
+			} else {
+				pool, err := database.Pool(org)
+				if err != nil {
+					t.Fatal(err)
+				}
+				deadline := time.Now().Add(4 * time.Second)
+				for {
+					var exists bool
+					if err = pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM slack_reply WHERE org_id = $1 AND investigation_id = $2)`, org.String(), id).Scan(&exists); err != nil {
+						t.Fatal(err)
+					}
+					if exists {
+						break
+					}
+					if time.Now().After(deadline) {
+						t.Fatal("worker did not claim delivery")
+					}
+					time.Sleep(20 * time.Millisecond)
+				}
+				// Let the first bounded pass read its empty or held event page.
+				time.Sleep(100 * time.Millisecond)
+			}
+			if err := database.AppendEvent(ctx, org, id, token, investigation.Event{Type: investigation.EventToolCompleted, Payload: map[string]any{"summary": "next batch"}}); err != nil {
+				t.Fatal(err)
+			}
+			awaitSlackText(t, sent, "next batch")
+		})
+	}
+}

--- a/internal/store/postgres/slack_reply.go
+++ b/internal/store/postgres/slack_reply.go
@@ -57,9 +57,8 @@ func oweSlackReplies(ctx context.Context, pool *pgxpool.Pool, limit int) error {
 
 // ClaimSlackReplies leases the replies that are due.
 //
-// The LEASE is what stops two workers writing into one visible message, which would be the one
-// failure a reader in the thread could not make sense of. It takes no organization for the
-// reason every other sweep does not: finding out which tenants owe an answer IS the question.
+// This cross-Organization sweep grants a unique token for each local delivery claim.
+// Provider acceptance is outside the database transaction.
 func (p *Database) ClaimSlackReplies(
 	ctx context.Context, limit int, lease time.Duration,
 ) ([]slack.Reply, error) {
@@ -71,6 +70,7 @@ func (p *Database) ClaimSlackReplies(
 	rows, err := p.pool.Query(ctx, `
 			UPDATE slack_reply
 			   SET status       = $1,
+			       lease_owner  = gen_random_uuid(),
 			       leased_until = now() + $2::interval,
 			       updated_at   = now()
 			 WHERE investigation_id IN (
@@ -83,7 +83,7 @@ func (p *Database) ClaimSlackReplies(
 			        LIMIT $4
 			          FOR UPDATE SKIP LOCKED)
 			RETURNING investigation_id, org_id, integration_id, conversation_id,
-			          channel_id, thread_ts, stream_ts, native, last_sequence, attempts`,
+			          channel_id, thread_ts, stream_ts, native, last_sequence, attempts, lease_owner, leased_until`,
 		SlackReplyDelivering, lease.String(), SlackReplyPending, limit)
 	if err != nil {
 		return nil, fmt.Errorf("claiming slack replies: %w", err)
@@ -98,7 +98,7 @@ func (p *Database) ClaimSlackReplies(
 		if err := rows.Scan(&one.Investigation, &organization, &one.Integration,
 			&one.Conversation, &one.Stream.Channel, &one.Stream.Thread,
 			&one.Stream.TS, &one.Stream.Native,
-			&one.LastSequence, &one.Attempts); err != nil {
+			&one.LastSequence, &one.Attempts, &one.ClaimToken, &one.LeaseExpiresAt); err != nil {
 			return nil, fmt.Errorf("scanning a slack reply: %w", err)
 		}
 		named, err := tenancy.NewOrganization(organization)
@@ -115,17 +115,13 @@ func (p *Database) ClaimSlackReplies(
 	return claimed, nil
 }
 
-// AdvanceSlackReply records progress. The cursor only ever moves forward, which is the
-// property that makes a retry append what was missed rather than repost what was seen.
+// AdvanceSlackReply saves acknowledged progress under the current claim.
 func (p *Database) AdvanceSlackReply(
-	ctx context.Context, organization tenancy.Organization, investigation uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, investigation, owner uuid.UUID,
 	made slack.Progress,
 ) error {
-	pool, err := p.Pool(organization)
-	if err != nil {
-		return err
-	}
-	if _, err := pool.Exec(ctx, `
+	return p.withSlackReplyClaim(ctx, organization, investigation, owner, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
 		UPDATE slack_reply
 		   SET stream_ts     = CASE WHEN stream_ts = '' THEN $3 ELSE stream_ts END,
 		       native     = CASE WHEN stream_ts = '' THEN $4 ELSE native END,
@@ -134,11 +130,12 @@ func (p *Database) AdvanceSlackReply(
 		       note          = '',
 		       updated_at    = now()
 		 WHERE investigation_id = $1 AND org_id = $2`,
-		investigation, organization.String(), made.Stream.TS, made.Stream.Native,
-		made.Sequence); err != nil {
-		return fmt.Errorf("advancing a slack reply: %w", err)
-	}
-	return nil
+			investigation, organization.String(), made.Stream.TS, made.Stream.Native,
+			made.Sequence); err != nil {
+			return fmt.Errorf("advancing a slack reply: %w", err)
+		}
+		return nil
+	})
 }
 
 // RecordCollaborationWrite puts one reply into a customer's workspace on the audit record.
@@ -171,20 +168,18 @@ func (p *Database) RecordCollaborationWrite(
 
 // CompleteSlackReply marks one delivered. Nothing claims it again.
 func (p *Database) CompleteSlackReply(
-	ctx context.Context, organization tenancy.Organization, investigation uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, investigation, owner uuid.UUID,
 ) error {
-	pool, err := p.Pool(organization)
-	if err != nil {
-		return err
-	}
-	if _, err := pool.Exec(ctx, `
+	return p.withSlackReplyClaim(ctx, organization, investigation, owner, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
 		UPDATE slack_reply
-		   SET status = $3, leased_until = NULL, updated_at = now()
+		   SET status = $3, leased_until = NULL, lease_owner = NULL, updated_at = now()
 		 WHERE investigation_id = $1 AND org_id = $2`,
-		investigation, organization.String(), SlackReplyDelivered); err != nil {
-		return fmt.Errorf("completing a slack reply: %w", err)
-	}
-	return nil
+			investigation, organization.String(), SlackReplyDelivered); err != nil {
+			return fmt.Errorf("completing a slack reply: %w", err)
+		}
+		return nil
+	})
 }
 
 // RetrySlackReply schedules another attempt, or gives up.
@@ -193,30 +188,29 @@ func (p *Database) CompleteSlackReply(
 // its own status and its own record. That separation is the point: a Slack outage must not be
 // able to make a completed investigation look failed.
 func (p *Database) RetrySlackReply(
-	ctx context.Context, organization tenancy.Organization, investigation uuid.UUID,
+	ctx context.Context, organization tenancy.Organization, investigation, owner uuid.UUID,
 	at time.Time, note string, giveUp bool,
 ) error {
-	pool, err := p.Pool(organization)
-	if err != nil {
-		return err
-	}
-	status := SlackReplyPending
-	if giveUp {
-		status = SlackReplyFailed
-	}
-	if _, err := pool.Exec(ctx, `
+	return p.withSlackReplyClaim(ctx, organization, investigation, owner, func(tx pgx.Tx) error {
+		status := SlackReplyPending
+		if giveUp {
+			status = SlackReplyFailed
+		}
+		if _, err := tx.Exec(ctx, `
 		UPDATE slack_reply
 		   SET status          = $3,
 		       attempts        = attempts + 1,
 		       next_attempt_at = $4,
 		       note            = $5,
 		       leased_until    = NULL,
+		       lease_owner     = NULL,
 		       updated_at      = now()
 		 WHERE investigation_id = $1 AND org_id = $2`,
-		investigation, organization.String(), status, at.UTC(), note); err != nil {
-		return fmt.Errorf("rescheduling a slack reply: %w", err)
-	}
-	return nil
+			investigation, organization.String(), status, at.UTC(), note); err != nil {
+			return fmt.Errorf("rescheduling a slack reply: %w", err)
+		}
+		return nil
+	})
 }
 
 // SlackReplyState reports what one reply looks like, for the tests and for support. It

--- a/internal/store/postgres/slack_reply_claim.go
+++ b/internal/store/postgres/slack_reply_claim.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/integrations/slack"
+)
+
+// ReleaseSlackReply schedules a normal flush independently of crash recovery.
+func (p *Database) ReleaseSlackReply(ctx context.Context, org tenancy.Organization, id, owner uuid.UUID, at time.Time) error {
+	return p.withSlackReplyClaim(ctx, org, id, owner, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE slack_reply SET status = $3, lease_owner = NULL,
+			leased_until = NULL, next_attempt_at = $4, updated_at = now()
+			WHERE org_id = $1 AND investigation_id = $2`, org.String(), id, SlackReplyPending, at.UTC())
+		return err
+	})
+}
+
+func (p *Database) withSlackReplyClaim(
+	ctx context.Context, org tenancy.Organization, id, owner uuid.UUID,
+	write func(pgx.Tx) error,
+) error {
+	pool, err := p.Pool(org)
+	if err != nil {
+		return err
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var locked uuid.UUID
+	err = tx.QueryRow(ctx, `SELECT investigation_id FROM slack_reply
+		WHERE org_id = $1 AND investigation_id = $2 FOR UPDATE`, org.String(), id).Scan(&locked)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return slack.ErrReplyClaimLost
+	}
+	if err != nil {
+		return fmt.Errorf("locking a slack reply: %w", err)
+	}
+	// Check expiry after acquiring the lock; waiting for it may outlive the claim.
+	var owned bool
+	if err = tx.QueryRow(ctx, `SELECT COALESCE(status = $4 AND lease_owner = $3
+		AND leased_until > clock_timestamp(), false) FROM slack_reply
+		WHERE org_id = $1 AND investigation_id = $2`, org.String(), id, owner, SlackReplyDelivering).Scan(&owned); err != nil {
+		return err
+	}
+	if !owned {
+		return slack.ErrReplyClaimLost
+	}
+	if err = write(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/store/postgres/slack_reply_fencing_test.go
+++ b/internal/store/postgres/slack_reply_fencing_test.go
@@ -1,0 +1,100 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/integrations/slack"
+)
+
+func TestExpiredSlackClaimCannotAdvance(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id, _ := aSlackTurn(t, database, org, "T1", "C1", "1700000000.1")
+	reply := claimed(t, database, id, -time.Second)
+	err := database.AdvanceSlackReply(ctx, org, id, reply.ClaimToken, slack.Progress{
+		Stream: slack.Stream{TS: "stale-message", Native: true}, Sequence: 9,
+	})
+	if err == nil {
+		t.Fatal("an expired worker advanced the reply")
+	}
+	_, sequence, message, _, found, err := database.SlackReplyState(ctx, org, id)
+	if err != nil || !found || sequence != 0 || message != "" {
+		t.Fatalf("stale write changed delivery: sequence=%d message=%q found=%v err=%v", sequence, message, found, err)
+	}
+}
+
+func TestReclaimedSlackReplyRejectsPreviousGeneration(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id, _ := aSlackTurn(t, database, org, "T1", "C1", "1700000000.1")
+	old := claimed(t, database, id, -time.Second)
+	current := claimed(t, database, id, time.Minute)
+	if old.ClaimToken == uuid.Nil || current.ClaimToken == uuid.Nil || old.ClaimToken == current.ClaimToken {
+		t.Fatal("each claim must have a distinct nonzero token")
+	}
+	for _, token := range []uuid.UUID{old.ClaimToken, uuid.Nil, uuid.New()} {
+		for _, write := range []func() error{
+			func() error {
+				return database.AdvanceSlackReply(ctx, org, id, token, slack.Progress{Stream: slack.Stream{TS: "stale"}, Sequence: 99})
+			},
+			func() error { return database.RetrySlackReply(ctx, org, id, token, time.Now(), "stale", true) },
+			func() error { return database.CompleteSlackReply(ctx, org, id, token) },
+			func() error { return database.ReleaseSlackReply(ctx, org, id, token, time.Now()) },
+		} {
+			if err := write(); !errors.Is(err, slack.ErrReplyClaimLost) {
+				t.Fatalf("stale mutation returned %v", err)
+			}
+		}
+	}
+	if err := database.AdvanceSlackReply(ctx, org, id, current.ClaimToken, slack.Progress{Stream: slack.Stream{TS: "current"}, Sequence: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.CompleteSlackReply(ctx, org, id, current.ClaimToken); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.RetrySlackReply(ctx, org, id, current.ClaimToken, time.Now(), "late retry", false); !errors.Is(err, slack.ErrReplyClaimLost) {
+		t.Fatalf("completed delivery accepted a retry: %v", err)
+	}
+	_, sequence, message, note, found, err := database.SlackReplyState(ctx, org, id)
+	if err != nil || !found || sequence != 2 || message != "current" || note != "" {
+		t.Fatalf("delivery changed: sequence=%d message=%q note=%q found=%v err=%v", sequence, message, note, found, err)
+	}
+}
+
+func TestSlackClaimMigrationPreservesHeldDelivery(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database, org := migratedDatabase(t)
+	id, _ := aSlackTurn(t, database, org, "T1", "C1", "1700000000.1")
+	reply := claimed(t, database, id, time.Minute)
+	if err := database.AdvanceSlackReply(ctx, org, id, reply.ClaimToken, slack.Progress{Stream: slack.Stream{TS: "retained"}, Sequence: 4}); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := database.Pool(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `ALTER TABLE slack_reply DROP COLUMN lease_owner; DELETE FROM schema_migration WHERE version = '0007_slack_reply_claim'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var owner uuid.UUID
+	if err = pool.QueryRow(ctx, `SELECT lease_owner FROM slack_reply WHERE org_id = $1 AND investigation_id = $2`, org.String(), id).Scan(&owner); err != nil || owner == uuid.Nil {
+		t.Fatalf("retained ownership: %v %v", owner, err)
+	}
+	if err = database.CompleteSlackReply(ctx, org, id, owner); err != nil {
+		t.Fatal(err)
+	}
+	_, sequence, message, _, found, err := database.SlackReplyState(ctx, org, id)
+	if err != nil || !found || sequence != 4 || message != "retained" {
+		t.Fatalf("migration changed delivery: %d %q %v %v", sequence, message, found, err)
+	}
+}

--- a/internal/store/postgres/slack_reply_test.go
+++ b/internal/store/postgres/slack_reply_test.go
@@ -65,7 +65,7 @@ func aSlackTurn(
 // the product does not reach.
 func claimed(
 	t *testing.T, database *storage.Database, investigation uuid.UUID, lease time.Duration,
-) {
+) slack.Reply {
 	t.Helper()
 
 	held, err := database.ClaimSlackReplies(context.Background(), 10, lease)
@@ -74,10 +74,11 @@ func claimed(
 	}
 	for _, one := range held {
 		if one.Investigation == investigation {
-			return
+			return one
 		}
 	}
 	t.Fatalf("the delivery for %s was not claimed: %+v", investigation, held)
+	return slack.Reply{}
 }
 
 func TestEveryTurnOfASlackConversationOwesAnAnswer(t *testing.T) {
@@ -244,14 +245,14 @@ func TestTheCursorOnlyEverMovesForward(t *testing.T) {
 	investigation, _ := aSlackTurn(t, database, organization,
 		"T0ACME", "C0INCIDENTS", "1700000001.1")
 	ctx := context.Background()
-	claimed(t, database, investigation, time.Minute)
+	reply := claimed(t, database, investigation, time.Minute)
 
-	if err := database.AdvanceSlackReply(ctx, organization, investigation,
+	if err := database.AdvanceSlackReply(ctx, organization, investigation, reply.ClaimToken,
 		slack.Progress{Stream: slack.Stream{TS: "1700000100.100", Native: true}, Sequence: 12}); err != nil {
 		t.Fatalf("advancing: %v", err)
 	}
 	// A later pass that somehow read an older batch must not undo it.
-	if err := database.AdvanceSlackReply(ctx, organization, investigation,
+	if err := database.AdvanceSlackReply(ctx, organization, investigation, reply.ClaimToken,
 		slack.Progress{Stream: slack.Stream{TS: "1700000100.100", Native: true}, Sequence: 4}); err != nil {
 		t.Fatalf("advancing backwards: %v", err)
 	}
@@ -266,7 +267,7 @@ func TestTheCursorOnlyEverMovesForward(t *testing.T) {
 	}
 	// And the visible message's identity is written once. A second identity would be a
 	// second message in the thread.
-	if err := database.AdvanceSlackReply(ctx, organization, investigation,
+	if err := database.AdvanceSlackReply(ctx, organization, investigation, reply.ClaimToken,
 		slack.Progress{Stream: slack.Stream{TS: "1700000999.999", Native: true}, Sequence: 13}); err != nil {
 		t.Fatalf("advancing: %v", err)
 	}
@@ -286,9 +287,9 @@ func TestGivingUpEndsTheDeliveryAndNotTheInvestigation(t *testing.T) {
 	investigation, _ := aSlackTurn(t, database, organization,
 		"T0ACME", "C0INCIDENTS", "1700000001.1")
 	ctx := context.Background()
-	claimed(t, database, investigation, time.Minute)
+	reply := claimed(t, database, investigation, time.Minute)
 
-	if err := database.RetrySlackReply(ctx, organization, investigation,
+	if err := database.RetrySlackReply(ctx, organization, investigation, reply.ClaimToken,
 		time.Now(), "slack would not open the reply", true); err != nil {
 		t.Fatalf("giving up: %v", err)
 	}
@@ -332,11 +333,9 @@ func TestADeliveredAnswerIsNeverClaimedAgain(t *testing.T) {
 	investigation, _ := aSlackTurn(t, database, organization,
 		"T0ACME", "C0INCIDENTS", "1700000001.1")
 	ctx := context.Background()
-	// A lease that has already expired, so what keeps this delivery from being claimed
-	// again is its STATE rather than a lease that has not run out yet.
-	claimed(t, database, investigation, -time.Second)
+	reply := claimed(t, database, investigation, time.Minute)
 
-	if err := database.CompleteSlackReply(ctx, organization, investigation); err != nil {
+	if err := database.CompleteSlackReply(ctx, organization, investigation, reply.ClaimToken); err != nil {
 		t.Fatalf("completing: %v", err)
 	}
 	claimed, err := database.ClaimSlackReplies(ctx, 10, time.Minute)

--- a/internal/store/postgres/slack_timeout_test.go
+++ b/internal/store/postgres/slack_timeout_test.go
@@ -1,0 +1,65 @@
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+	"github.com/open-cluster/oc-control-plane/internal/store/postgres"
+)
+
+func TestSlackAttemptTimeoutPreservesRetryBudget(t *testing.T) {
+	for _, previous := range []int{0, 7} {
+		t.Run(fmt.Sprintf("previous=%d", previous), func(t *testing.T) {
+			t.Parallel()
+			database, org, id, worker := slackDelivery(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				select {
+				case <-r.Context().Done():
+				case <-time.After(3 * time.Second):
+				}
+			}))
+			ctx := context.Background()
+			if err := database.ConcludeInvestigation(ctx, org, id, claimToken(t, database, org, id), conclusionSaying("durable answer"), "", investigation.Usage{}); err != nil {
+				t.Fatal(err)
+			}
+			pool, err := database.Pool(org)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Shorten the actual database claim, preserving the worker's deadline calculation.
+			if _, err = pool.Exec(ctx, fmt.Sprintf(`CREATE FUNCTION short_slack_claim() RETURNS trigger LANGUAGE plpgsql AS $$
+				BEGIN IF NEW.lease_owner IS NOT NULL AND NEW.lease_owner IS DISTINCT FROM OLD.lease_owner THEN
+				NEW.leased_until := clock_timestamp() + interval '2 seconds'; NEW.attempts := %d;
+				END IF; RETURN NEW; END $$;
+				CREATE TRIGGER short_slack_claim BEFORE UPDATE ON slack_reply FOR EACH ROW EXECUTE FUNCTION short_slack_claim()`, previous)); err != nil {
+				t.Fatal(err)
+			}
+			stop := runSlackWorker(t, worker)
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				var attempts, status int
+				var settled bool
+				if err = pool.QueryRow(ctx, `SELECT attempts, status, lease_owner IS NULL AND leased_until IS NULL AND next_attempt_at > now()
+					FROM slack_reply WHERE org_id = $1 AND investigation_id = $2`, org.String(), id).Scan(&attempts, &status, &settled); err == nil && attempts == previous+1 {
+					want := storage.SlackReplyPending
+					if previous == 7 {
+						want = storage.SlackReplyFailed
+					}
+					if status != want || !settled {
+						t.Fatalf("timeout settlement: status=%d attempts=%d released/backoff=%v", status, attempts, settled)
+					}
+					stop()
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("timeout bypassed retry accounting: attempts=%d status=%d err=%v", attempts, status, err)
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Slack replies could wait for the two-minute recovery lease after empty, held or successful nonterminal passes. Expired workers could also overwrite delivery state, and a failed native stream close was lost after its cursor advanced. Normal passes now release ownership and schedule the next flush separately. A forward migration adds a unique lease_owner UUID, and identity, progress, retry, release and completion require the current unexpired claim after locking the row.

The worker claims each reply just before processing and bounds provider work before lease expiry. Remaining lease time settles timeout retry accounting, preserving backoff and exhaustion. A terminal cursor recovers stream closure without re-appending acknowledged content; Slack's documented message_not_in_streaming_state response means closure is already achieved.

Provider acceptance remains at least once. Native/fallback HTTP tests pause identity persistence after acceptance, interrupt the worker and restart against the retained database, explicitly observing a duplicate visible message and successful recovery. Product documentation states that boundary and the corresponding native-append risk. The [Slack startStream](https://docs.slack.dev/reference/methods/chat.startStream/) and [postMessage](https://docs.slack.dev/reference/methods/chat.postMessage/) references do not document an applicable idempotent-create guarantee; database fencing is not presented as one. The [stopStream reference](https://docs.slack.dev/reference/methods/chat.stopStream/) documents the already-stopped response.

Validation: focused real PostgreSQL/Slack HTTP RED/GREEN tests and race regressions pass for cadence, token fencing, migration preservation, acceptance/restart, close retry and timeout budget exhaustion. Existing Slack tests and final-head lint pass. Both independent reviews are clear after correcting the cadence test's timing assumption and preserving timeout retry accounting. Final-head CI passed in 10m11s, documentation validation in 1m7s, and Mintlify deployment passed. Full local application/PostgreSQL/composed HTTP/E2E race suites, lint, architecture, documentation, vulnerability call-path scans, license checks, Helm, backend image build and secret scanning passed; the final review corrections also passed focused race tests. Full make verify is not green: the existing frontend Dockerfile references missing web/. Stop old control-plane replicas before upgrading the token-fenced worker.

This completes the planned delivery implementation for issue #48 phase 3; F12 quota fixes already shipped in #57. Copied routing removal and composite relationship constraints remain with phase 4's coordinated retained-data migration. Issue #48 remains open for the other phases.
