### PR TITLE
Preserve originating Investigation evidence references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ independently of crash recovery; provider acceptance remains an
 Stop old replicas before upgrading Slack delivery fencing as well.
 Messages may select an explicit time window; queued batches retain their accepted bounds.
 See [question windows](docs/concepts/investigations-and-conversations.mdx) for defaults and conflicts.
+Reused Finding citations retain their originating Investigation and Tool Run; unavailable evidence is marked in result detail.
 
 Conversation detail includes the first 50 turns; use `turnsNext` with the turns endpoint
 to continue reading in order, with up to 200 turns per page.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1754,13 +1754,30 @@ components:
       type: object
       additionalProperties: false
       required: [id, statement, kind, confidence, mechanism, runRefs]
+      anyOf:
+        - properties:
+            runRefs: { minItems: 1 }
+        - required: [evidenceRefs]
+          properties:
+            evidenceRefs: { minItems: 1 }
       properties:
         id: { type: string, minLength: 1, maxLength: 128 }
         statement: { type: string, minLength: 1, maxLength: 4096 }
         kind: { type: string, enum: [cause, trigger, contributing_factor, symptom, propagation, ruled_out, unresolved, observation] }
         confidence: { type: string, enum: [confirmed, likely, possible] }
         mechanism: { type: string, maxLength: 4096 }
-        runRefs: { type: array, minItems: 1, items: { type: integer, minimum: 1 }, uniqueItems: true }
+        runRefs: { type: array, items: { type: integer, minimum: 1 }, uniqueItems: true }
+        evidenceRefs:
+          type: array
+          uniqueItems: true
+          items: { $ref: "#/components/schemas/EvidenceRef" }
+    EvidenceRef:
+      type: object
+      additionalProperties: false
+      required: [investigationId, toolRunOrdinal]
+      properties:
+        investigationId: { $ref: "#/components/schemas/UUID" }
+        toolRunOrdinal: { type: integer, minimum: 1 }
     Hypothesis:
       type: object
       additionalProperties: false

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3723,6 +3723,15 @@ components:
         - confidence
         - mechanism
         - runRefs
+      anyOf:
+        - properties:
+            runRefs:
+              minItems: 1
+        - required:
+            - evidenceRefs
+          properties:
+            evidenceRefs:
+              minItems: 1
       properties:
         id:
           type: string
@@ -3754,11 +3763,27 @@ components:
           maxLength: 4096
         runRefs:
           type: array
-          minItems: 1
           items:
             type: integer
             minimum: 1
           uniqueItems: true
+        evidenceRefs:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvidenceRef'
+    EvidenceRef:
+      type: object
+      additionalProperties: false
+      required:
+        - investigationId
+        - toolRunOrdinal
+      properties:
+        investigationId:
+          $ref: '#/components/schemas/UUID'
+        toolRunOrdinal:
+          type: integer
+          minimum: 1
     Hypothesis:
       type: object
       additionalProperties: false

--- a/docs/concepts/investigations-and-conversations.mdx
+++ b/docs/concepts/investigations-and-conversations.mdx
@@ -76,6 +76,14 @@ Citations show what OpenCluster read, not that the source was complete or correc
 source timestamps, bounded windows, contradictions, and truncation before accepting a
 Finding.
 
+In API results, `runRefs` names Tool Run ordinals in the containing Investigation.
+Reused Findings use `evidenceRefs` pairs of `investigationId` and `toolRunOrdinal`;
+follow the referenced Investigation's detail and `runs` to resolve them. Two Investigations
+can each have Run 1, so the ordinal alone cannot identify reused evidence.
+Unavailable or unauthorized Investigations return the same `404`. If a cited Tool Run
+has been pruned, the Finding retains its reference and detail reports a `missing_telemetry`
+limitation; it does not substitute another run or claim fresh verification.
+
 ## Action Proposals
 
 An Action Proposal can describe mitigation, rollback, verification, a permanent fix, or

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -243,6 +243,12 @@ func (r *Agent) Run(
 	state.orientationText = renderOrientation(oriented)
 	state.tools = exchangeTools(oriented)
 	state.carried = orientationTokens(oriented)
+	var priorEvidence []investigation.EvidenceRef
+	if oriented.Brief != nil {
+		for _, finding := range oriented.Brief.Findings {
+			priorEvidence = append(priorEvidence, finding.References()...)
+		}
+	}
 
 	var results []toolFeedback
 	stagnant := 0
@@ -332,7 +338,7 @@ func (r *Agent) Run(
 			}
 			if conclude != nil {
 				conclusion, decodeErr := decodeConclusion(
-					conclude.Arguments, state.highestOrdinal, false)
+					conclude.Arguments, state.highestOrdinal, priorEvidence)
 				if decodeErr != nil {
 					if attempt == 0 {
 						continue
@@ -340,6 +346,9 @@ func (r *Agent) Run(
 					err = Failed(OutcomeMalformed, r.deployment.Provider,
 						completion.Model, decodeErr.Error())
 					break
+				}
+				if oriented.Brief != nil && oriented.Brief.MissingEvidence {
+					conclusion.MarkMissingEvidence()
 				}
 				move.Conclusion = &conclusion
 				break

--- a/internal/investigation/agent/conclusion.go
+++ b/internal/investigation/agent/conclusion.go
@@ -6,11 +6,13 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/open-cluster/oc-control-plane/internal/investigation"
 )
 
 // SchemaVersion identifies the conclusion document shape.
-const SchemaVersion = "6"
+const SchemaVersion = "7"
 
 type properties map[string]any
 
@@ -80,7 +82,7 @@ func splitCalls(calls []CompletionCall) (reads []CompletionCall, conclude *Compl
 // kinds and confidences must be the declared vocabulary, and the texts must fit the
 // record.
 func decodeConclusion(
-	document []byte, runs int, _ bool,
+	document []byte, runs int, allowed []investigation.EvidenceRef,
 ) (investigation.Conclusion, error) {
 	var decoded struct {
 		Status  string `json:"status"`
@@ -94,12 +96,13 @@ func decodeConclusion(
 			RunRefs          []int    `json:"run_refs"`
 		} `json:"impact"`
 		Findings []struct {
-			ID         string `json:"id"`
-			Statement  string `json:"statement"`
-			Kind       string `json:"kind"`
-			Confidence string `json:"confidence"`
-			Mechanism  string `json:"mechanism"`
-			RunRefs    []int  `json:"run_refs"`
+			ID           string                      `json:"id"`
+			Statement    string                      `json:"statement"`
+			Kind         string                      `json:"kind"`
+			Confidence   string                      `json:"confidence"`
+			Mechanism    string                      `json:"mechanism"`
+			RunRefs      []int                       `json:"run_refs"`
+			EvidenceRefs []investigation.EvidenceRef `json:"evidence_refs"`
 		} `json:"findings"`
 		Hypotheses []struct {
 			ID, Statement, Status, Test string
@@ -171,11 +174,21 @@ func decodeConclusion(
 				"a finding's confidence %q is not confirmed, likely or possible",
 				finding.Confidence)
 		}
-		if len(finding.RunRefs) == 0 {
+		if len(finding.RunRefs) == 0 && len(finding.EvidenceRefs) == 0 {
 			return investigation.Conclusion{}, fmt.Errorf("a finding cites no run at all")
 		}
 		if err := validateRunRefs(finding.RunRefs, runs, "finding"); err != nil {
 			return investigation.Conclusion{}, err
+		}
+		seenEvidence := make(map[investigation.EvidenceRef]bool, len(finding.EvidenceRefs))
+		for _, ref := range finding.EvidenceRefs {
+			if ref.InvestigationID == uuid.Nil || ref.ToolRunOrdinal <= 0 || !slices.Contains(allowed, ref) {
+				return investigation.Conclusion{}, fmt.Errorf("a finding cites unavailable prior evidence")
+			}
+			if seenEvidence[ref] {
+				return investigation.Conclusion{}, fmt.Errorf("a finding repeats prior evidence")
+			}
+			seenEvidence[ref] = true
 		}
 		if causalFinding(finding.Kind) && strings.TrimSpace(finding.Mechanism) == "" {
 			return investigation.Conclusion{}, fmt.Errorf("causal finding %q has no mechanism", finding.ID)
@@ -183,6 +196,7 @@ func decodeConclusion(
 		conclusion.Findings = append(conclusion.Findings, investigation.Finding{
 			ID: finding.ID, Statement: finding.Statement, Kind: finding.Kind,
 			Confidence: finding.Confidence, Mechanism: finding.Mechanism, Sources: finding.RunRefs,
+			EvidenceRefs: finding.EvidenceRefs,
 		})
 	}
 	for _, hypothesis := range decoded.Hypotheses {

--- a/internal/investigation/agent/conclusion_test.go
+++ b/internal/investigation/agent/conclusion_test.go
@@ -43,7 +43,7 @@ func TestStructuredConclusionContractRequiresMechanismForAVerifiedCause(t *testi
 		t.Fatal(err)
 	}
 
-	if _, err := decodeConclusion(document, 1, false); err == nil {
+	if _, err := decodeConclusion(document, 1, nil); err == nil {
 		t.Fatal("a verified cause without a causal mechanism was accepted")
 	}
 
@@ -64,7 +64,7 @@ func TestStructuredConclusionEvaluationFixtures(t *testing.T) {
 			if marshalErr != nil {
 				t.Fatal(marshalErr)
 			}
-			_, decodeErr := decodeConclusion(encoded, fixture.Runs, false)
+			_, decodeErr := decodeConclusion(encoded, fixture.Runs, nil)
 			if fixture.Valid && decodeErr != nil {
 				t.Fatalf("valid fixture was rejected: %v", decodeErr)
 			}
@@ -92,7 +92,7 @@ func TestStructuredConclusionRequiresCitationsForImpactAndActions(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := decodeConclusion(encoded, 1, false); err == nil {
+	if _, err := decodeConclusion(encoded, 1, nil); err == nil {
 		t.Fatal("partial impact without a Run reference was accepted")
 	}
 
@@ -110,7 +110,7 @@ func TestStructuredConclusionRequiresCitationsForImpactAndActions(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := decodeConclusion(encoded, 1, false); err == nil {
+	if _, err := decodeConclusion(encoded, 1, nil); err == nil {
 		t.Fatal("an action without a Run reference was accepted")
 	}
 }

--- a/internal/investigation/agent/evidence_test.go
+++ b/internal/investigation/agent/evidence_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+	"strings"
+	"testing"
+)
+
+func TestConclusionPreservesCrossInvestigationEvidence(t *testing.T) {
+	document := []byte(`{
+		"status":"answer_only", "summary":"Earlier observations remain available.",
+		"impact":{"status":"unknown","current_state":"unknown","summary":"Impact is unknown.","run_refs":[]},
+		"findings":[{"id":"prior","statement":"The earlier deploy changed the pool.",
+		"kind":"observation","confidence":"confirmed","mechanism":"","run_refs":[],
+		"evidence_refs":[{"investigationId":"11111111-1111-4111-8111-111111111111","toolRunOrdinal":1}]}]
+	}`)
+	ref := investigation.EvidenceRef{InvestigationID: uuid.MustParse("11111111-1111-4111-8111-111111111111"), ToolRunOrdinal: 1}
+	conclusion, err := decodeConclusion(document, 0, []investigation.EvidenceRef{ref})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conclusion.Findings) != 1 || len(conclusion.Findings[0].EvidenceRefs) != 1 || conclusion.Findings[0].EvidenceRefs[0] != ref {
+		t.Fatalf("lost reused Finding: %+v", conclusion)
+	}
+	if _, err := decodeConclusion(document, 0, nil); err == nil {
+		t.Fatal("accepted a citation outside the authorized prior evidence")
+	}
+	pair := `{"investigationId":"11111111-1111-4111-8111-111111111111","toolRunOrdinal":1}`
+	duplicated := []byte(strings.Replace(string(document), pair, pair+","+pair, 1))
+	if _, err := decodeConclusion(duplicated, 0, []investigation.EvidenceRef{ref}); err == nil {
+		t.Fatal("accepted duplicate evidence references")
+	}
+}

--- a/internal/investigation/agent/prompt.go
+++ b/internal/investigation/agent/prompt.go
@@ -186,7 +186,8 @@ func ConcludeDefinition() integrations.ToolDefinition {
 		Description: "End the investigation with its structured conclusion. Call this " +
 			"exactly once, when your reads are done: status, concise summary, impact, " +
 			"findings, hypotheses, proposed actions, and limitations. Return no " +
-			"findings rather than a guess when nothing was established. Keep the answer " +
+			"findings rather than a guess when nothing was established. " +
+			"Cite this Investigation's runs with run_refs; reuse only supplied prior evidence_refs pairs. Keep the answer " +
 			"under " + strconv.Itoa(investigation.MaxSummaryLength) + " characters — it " +
 			"is the reply an operator reads first, not the report; the detail belongs in " +
 			"the findings, which are not bounded by it. A longer answer is cut to fit.",
@@ -227,6 +228,10 @@ func agentFindingSchema() map[string]any {
 		"confidence": enumField(investigation.Confidences...),
 		"mechanism":  stringField,
 		"run_refs":   array(integerField),
+		"evidence_refs": array(object(properties{
+			"investigationId": map[string]any{"type": "string", "format": "uuid"},
+			"toolRunOrdinal":  map[string]any{"type": "integer", "minimum": 1},
+		})),
 	})
 }
 
@@ -651,7 +656,7 @@ func writeFindings(
 			}
 			line += ")"
 		}
-		out.WriteString(line + " [" + finding.Reference() + "]\n")
+		out.WriteString(line + " evidence_refs=" + finding.Reference() + "\n")
 	}
 }
 

--- a/internal/investigation/brief.go
+++ b/internal/investigation/brief.go
@@ -1,8 +1,7 @@
 package investigation
 
 import (
-	"strconv"
-	"strings"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,32 +44,36 @@ type BriefMessage struct {
 	InvestigationID uuid.UUID
 }
 
-// PriorFinding is something an earlier turn established, with its citation as a reference.
-// Turn and Runs together name exactly where the evidence is without carrying any of it.
+// PriorFinding retains the canonical origin of an earlier observation.
 type PriorFinding struct {
-	Turn       int
-	Statement  string
-	Kind       string
-	Confidence string
-	Runs       []int
+	InvestigationID uuid.UUID
+	Turn            int
+	Statement       string
+	Kind            string
+	Confidence      string
+	Runs            []int
+	EvidenceRefs    []EvidenceRef
 }
 
-// Reference renders the citation an operator or a model can follow: which turn, which runs.
-func (p PriorFinding) Reference() string {
-	if len(p.Runs) == 0 {
-		return "turn " + strconv.Itoa(p.Turn)
-	}
-	ordinals := make([]string, 0, len(p.Runs))
+func (p PriorFinding) References() []EvidenceRef {
+	refs := append([]EvidenceRef{}, p.EvidenceRefs...)
 	for _, run := range p.Runs {
-		ordinals = append(ordinals, strconv.Itoa(run))
+		refs = append(refs, EvidenceRef{InvestigationID: p.InvestigationID, ToolRunOrdinal: run})
 	}
-	return "turn " + strconv.Itoa(p.Turn) + " run " + strings.Join(ordinals, ", ")
+	return refs
+}
+
+// Reference renders the exact pairs accepted by the conclusion's evidence_refs field.
+func (p PriorFinding) Reference() string {
+	encoded, _ := json.Marshal(p.References())
+	return string(encoded)
 }
 
 // Brief is one conversation's contribution to a turn's Orientation.
 type Brief struct {
-	ConversationID string
-	Subject        string
+	MissingEvidence bool
+	ConversationID  string
+	Subject         string
 	// Turn is this turn's one-based position, so the agent knows it is not the first.
 	Turn int
 	// Recent is the verbatim tail, oldest first.

--- a/internal/investigation/evidence.go
+++ b/internal/investigation/evidence.go
@@ -1,0 +1,20 @@
+package investigation
+
+import "github.com/google/uuid"
+
+// EvidenceRef identifies a Tool Run outside the containing Investigation.
+type EvidenceRef struct {
+	InvestigationID uuid.UUID `json:"investigationId"`
+	ToolRunOrdinal  int       `json:"toolRunOrdinal"`
+}
+
+const MissingEvidenceStatement = "Some cited Tool Runs are no longer available. Retained Findings have not been reverified."
+
+func (c *Conclusion) MarkMissingEvidence() {
+	for _, limitation := range c.Limitations {
+		if limitation.Type == LimitationMissingTelemetry && limitation.Statement == MissingEvidenceStatement {
+			return
+		}
+	}
+	c.Limitations = append(c.Limitations, Limitation{Type: LimitationMissingTelemetry, Statement: MissingEvidenceStatement, RunRefs: []int{}})
+}

--- a/internal/investigation/handler.go
+++ b/internal/investigation/handler.go
@@ -384,7 +384,8 @@ type findingView struct {
 	Confidence string `json:"confidence,omitempty"`
 	Mechanism  string `json:"mechanism,omitempty"`
 	// Sources are one-based ordinals among the investigation's runs.
-	RunRefs []int `json:"runRefs"`
+	RunRefs      []int         `json:"runRefs"`
+	EvidenceRefs []EvidenceRef `json:"evidenceRefs,omitempty"`
 }
 
 type usageView struct {
@@ -450,6 +451,7 @@ func investigationViewOf(found Investigation) investigationView {
 		findings = append(findings, findingView{
 			ID: finding.ID, Statement: finding.Statement, Kind: finding.Kind,
 			Confidence: finding.Confidence, Mechanism: finding.Mechanism, RunRefs: finding.Sources,
+			EvidenceRefs: finding.EvidenceRefs,
 		})
 	}
 	humanConfirmationRequired := false

--- a/internal/investigation/investigation.go
+++ b/internal/investigation/investigation.go
@@ -68,10 +68,9 @@ type Finding struct {
 	Confidence string `json:"confidence"`
 	// Mechanism is required for causal findings and explains how the cause produced impact.
 	Mechanism string `json:"mechanism"`
-	// Sources are one-based ordinals among the investigation's recorded tool runs. Every
-	// finding cites at least one — enforced when the reasoner's answer is decoded — so a
-	// statement nothing was read for cannot be stored as established.
-	Sources []int `json:"runRefs"`
+	// Sources name local runs; EvidenceRefs retain the origins of reused runs.
+	Sources      []int         `json:"runRefs"`
+	EvidenceRefs []EvidenceRef `json:"evidenceRefs,omitempty"`
 }
 
 const (

--- a/internal/store/postgres/conversation_brief.go
+++ b/internal/store/postgres/conversation_brief.go
@@ -81,6 +81,17 @@ func (p *Database) ConversationBrief(
 	if err = readPriorTurns(ctx, pool, organization, id, &brief); err != nil {
 		return investigation.Brief{}, err
 	}
+	var refs []investigation.EvidenceRef
+	for _, finding := range brief.Findings {
+		refs = append(refs, finding.References()...)
+	}
+	brief.MissingEvidence, err = evidenceMissing(ctx, pool, organization, refs)
+	if err != nil {
+		return investigation.Brief{}, fmt.Errorf("checking prior evidence: %w", err)
+	}
+	if brief.MissingEvidence {
+		brief.Limitations = append(brief.Limitations, investigation.MissingEvidenceStatement)
+	}
 	return brief, nil
 }
 
@@ -192,12 +203,10 @@ func readPriorTurns(
 	// That second half is the whole of what conversations about one incident share.
 	// FINDINGS ONLY: durable, cited, incident-level fact. Never another conversation's
 	// messages and never its summary, because what somebody else asked and was told is
-	// theirs. A sibling turn carries no ordinal in this conversation, so its citation
-	// references turn 0 — which reads as "established elsewhere on this incident" rather
-	// than as a turn of this conversation that nobody can find.
+	// theirs. Citations retain Investigation identity independently of local turn ordinals.
 	rows, err := pool.Query(ctx, `
 		SELECT CASE WHEN turn.conversation_id = $2 THEN turn.turn ELSE 0 END,
-		       turn.conclusion
+		       turn.investigation_id, turn.conclusion
 		  FROM investigation turn
 		 WHERE turn.org_id = $1
 		   AND turn.status = 2
@@ -216,10 +225,11 @@ func readPriorTurns(
 
 	for rows.Next() {
 		var (
-			turn       int
-			conclusion []byte
+			investigationID uuid.UUID
+			turn            int
+			conclusion      []byte
 		)
-		if err = rows.Scan(&turn, &conclusion); err != nil {
+		if err = rows.Scan(&turn, &investigationID, &conclusion); err != nil {
 			return fmt.Errorf("scanning a prior turn: %w", err)
 		}
 		var decoded investigation.Conclusion
@@ -253,11 +263,13 @@ func readPriorTurns(
 		prior := make([]investigation.PriorFinding, 0, len(decoded.Findings))
 		for _, finding := range decoded.Findings {
 			prior = append(prior, investigation.PriorFinding{
-				Turn:       turn,
-				Statement:  finding.Statement,
-				Kind:       finding.Kind,
-				Confidence: finding.Confidence,
-				Runs:       finding.Sources,
+				InvestigationID: investigationID,
+				Turn:            turn,
+				Statement:       finding.Statement,
+				Kind:            finding.Kind,
+				Confidence:      finding.Confidence,
+				Runs:            finding.Sources,
+				EvidenceRefs:    finding.EvidenceRefs,
 			})
 		}
 		brief.Findings = append(prior, brief.Findings...)

--- a/internal/store/postgres/conversation_test.go
+++ b/internal/store/postgres/conversation_test.go
@@ -532,6 +532,9 @@ func TestConversationsOnOneIncidentShareFindingsAndNothingElse(t *testing.T) {
 	for _, finding := range brief.Findings {
 		if finding.Statement == "the deploy at 14:02 changed the pool size" {
 			shared = true
+			if !strings.Contains(finding.Reference(), adaTurn.InvestigationID.String()) {
+				t.Errorf("shared citation lost its originating Investigation: %s", finding.Reference())
+			}
 			if len(finding.Runs) == 0 {
 				t.Errorf("the shared finding lost its citation: %+v", finding)
 			}
@@ -568,6 +571,24 @@ func TestConversationsOnOneIncidentShareFindingsAndNothingElse(t *testing.T) {
 	if len(unrelated.Findings) != 0 {
 		t.Errorf("a conversation about another incident carries %d findings from this one",
 			len(unrelated.Findings))
+	}
+	pool, err := database.Pool(organization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(context.Background(), `DELETE FROM investigation_tool_run WHERE org_id = $1 AND investigation_id = $2`, organization.String(), adaTurn.InvestigationID); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := database.Investigation(context.Background(), organization, adaTurn.InvestigationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := false
+	for _, limitation := range retained.Conclusion.Limitations {
+		missing = missing || limitation.Type == investigation.LimitationMissingTelemetry
+	}
+	if !missing || len(retained.Conclusion.Findings[0].Sources) != 1 {
+		t.Fatalf("pruned evidence lost its citation or limitation: %+v", retained.Conclusion)
 	}
 }
 

--- a/internal/store/postgres/evidence.go
+++ b/internal/store/postgres/evidence.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func evidenceMissing(ctx context.Context, pool querier, org tenancy.Organization, refs []investigation.EvidenceRef) (bool, error) {
+	if len(refs) == 0 {
+		return false, nil
+	}
+	ids := make([]uuid.UUID, 0, len(refs))
+	ordinals := make([]int64, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.InvestigationID)
+		ordinals = append(ordinals, int64(ref.ToolRunOrdinal))
+	}
+	var missing bool
+	err := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM unnest($2::uuid[], $3::bigint[]) AS reference(investigation_id, ordinal)
+		WHERE NOT EXISTS (SELECT 1 FROM investigation_tool_run run
+			WHERE run.org_id = $1 AND run.investigation_id = reference.investigation_id
+			AND run.ordinal = reference.ordinal))`, org.String(), ids, ordinals).Scan(&missing)
+	return missing, err
+}
+
+func resultEvidence(found investigation.Investigation) []investigation.EvidenceRef {
+	var refs []investigation.EvidenceRef
+	for _, finding := range found.Conclusion.Findings {
+		refs = append(refs, finding.EvidenceRefs...)
+		for _, ordinal := range finding.Sources {
+			refs = append(refs, investigation.EvidenceRef{InvestigationID: found.ID, ToolRunOrdinal: ordinal})
+		}
+	}
+	return refs
+}

--- a/internal/store/postgres/investigation.go
+++ b/internal/store/postgres/investigation.go
@@ -88,6 +88,13 @@ func (p *Database) Investigation(
 	if err != nil {
 		return investigation.Investigation{}, fmt.Errorf("reading an investigation: %w", err)
 	}
+	missing, err := evidenceMissing(ctx, pool, organization, resultEvidence(found))
+	if err != nil {
+		return investigation.Investigation{}, fmt.Errorf("checking cited evidence: %w", err)
+	}
+	if missing {
+		found.Conclusion.MarkMissingEvidence()
+	}
 	return found, nil
 }
 

--- a/test/controlplane/evidence_test.go
+++ b/test/controlplane/evidence_test.go
@@ -1,0 +1,87 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/open-cluster/oc-control-plane/internal/investigation"
+)
+
+func TestEvidenceReferencesResolveDistinctRunsAndSurvivePruning(t *testing.T) {
+	plane := startIntegrationPlane(t)
+	ctx := context.Background()
+	database, err := pgx.Connect(ctx, plane.dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close(ctx) }()
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	refs := []investigation.EvidenceRef{{InvestigationID: ids[0], ToolRunOrdinal: 1}, {InvestigationID: ids[1], ToolRunOrdinal: 1}}
+	for index, id := range ids {
+		conclusion := investigation.Conclusion{Status: investigation.AnswerOnly, Summary: "Prior observations."}
+		if index == 2 {
+			conclusion.Findings = []investigation.Finding{{ID: "reused", Statement: "Two prior observations.", Kind: investigation.FindingObservation,
+				Confidence: investigation.ConfidenceConfirmed, Sources: []int{}, EvidenceRefs: refs}}
+		}
+		encoded, err := json.Marshal(conclusion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = database.Exec(ctx, `INSERT INTO investigation
+			(investigation_id, org_id, subject, window_from, window_until, status, concluded_at, conclusion)
+			VALUES ($1,$2,'citation fixture',now()-interval '1 hour',now(),2,now(),$3)`, id, surfaceOrg, encoded); err != nil {
+			t.Fatal(err)
+		}
+		if index < 2 {
+			if _, err = database.Exec(ctx, `INSERT INTO investigation_tool_run
+				(investigation_id,org_id,ordinal,tool,window_from,window_until,outcome,summary,started_at,finished_at)
+				VALUES ($1,$2,1,'read',now()-interval '1 hour',now(),1,$3,now(),now())`, id, surfaceOrg, id.String()); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	for _, ref := range refs {
+		status, body := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+ref.InvestigationID.String(), nil)
+		var source struct {
+			Runs []struct {
+				Ordinal int
+				Summary string
+			}
+		}
+		decodeInto(t, body, &source)
+		if status != http.StatusOK || len(source.Runs) != 1 || source.Runs[0].Ordinal != 1 || source.Runs[0].Summary != ref.InvestigationID.String() {
+			t.Fatalf("citation resolved to the wrong run: %d %s", status, body)
+		}
+		if status, body = plane.call(t, http.MethodGet, plane.base(neighbourOrg)+"/investigations/"+ref.InvestigationID.String(), nil); status != http.StatusNotFound {
+			t.Fatalf("cross-Organization citation disclosed data: %d %s", status, body)
+		}
+	}
+	for _, prune := range []bool{false, true} {
+		if prune {
+			if _, err = database.Exec(ctx, `DELETE FROM investigation_tool_run WHERE org_id=$1 AND investigation_id=$2`, surfaceOrg, ids[0]); err != nil {
+				t.Fatal(err)
+			}
+		}
+		status, body := plane.call(t, http.MethodGet, plane.base(surfaceOrg)+"/investigations/"+ids[2].String(), nil)
+		var result struct {
+			Findings    []investigation.Finding
+			Limitations []investigation.Limitation
+		}
+		decodeInto(t, body, &result)
+		if status != http.StatusOK || len(result.Findings) != 1 || !slices.Equal(result.Findings[0].EvidenceRefs, refs) {
+			t.Fatalf("lost evidence origins: %d %s", status, body)
+		}
+		missing := slices.ContainsFunc(result.Limitations, func(item investigation.Limitation) bool { return item.Type == investigation.LimitationMissingTelemetry })
+		if missing != prune {
+			t.Fatalf("wrong evidence availability: %s", body)
+		}
+		if prune && result.Limitations[0].RunRefs == nil {
+			t.Fatalf("missing-evidence limitation has null runRefs: %s", body)
+		}
+	}
+}


### PR DESCRIPTION
Reused Findings now retain the originating Investigation ID and Tool Run ordinal in evidenceRefs. Local runRefs keep their existing meaning. Prior Finding projections and model conclusions carry those pairs, and the model can only reuse references supplied in its authorized history.

Result detail and subsequent conclusions expose missing_telemetry when cited runs have been pruned, preserving the original references. A single Organization-scoped existence query checks availability; no evidence table or mutable answer copy is introduced. Public schemas and documentation describe the result.

Validation: existing PostgreSQL sibling-sharing regression, model conclusion allowlist/duplicate regression, and composed HTTP checks for distinct Run 1 origins, tenant refusal and pruning pass. Independent standards/spec reviews are clear after correcting the empty runRefs array and duplicate-reference validation. Full backend verification passed, including race-enabled PostgreSQL and composed-process tests, E2E, vulnerability, license, secret-history, API, docs, and deployment checks. The repository's existing frontend image check still fails because deploy/compose/Frontend.Dockerfile copies an absent web/ directory; this slice does not alter that path. GitHub CI, documentation validation, and Mintlify checks pass.

Part of #48 phase 5. History retrieval and brief cleanup, provider request budgets, configuration and model evaluations follow separately before phase 4.
