### PR TITLE
fix: budget full model requests and bound context recovery

### DIFF
--- a/internal/integrations/catalog_test.go
+++ b/internal/integrations/catalog_test.go
@@ -85,7 +85,7 @@ func TestTheProductDocumentationURLIsDerivedFromTheDefinition(t *testing.T) {
 	// directory is the Category and the page is the Key. Derived rather than declared, so
 	// a hand-written URL cannot drift away from the page it names.
 	definition := Definition{Manifest: Manifest{DocumentationSlug: "integrations/collaboration/slack"}}
-	const want = "https://docs.opencluster.dev/integrations/collaboration/slack"
+	const want = "https://docs.open-cluster.io/integrations/collaboration/slack"
 	if got := definition.ProductDocumentationURL(); got != want {
 		t.Errorf("ProductDocumentationURL() = %q, want %q", got, want)
 	}

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -147,7 +147,7 @@ type Manifest struct {
 // documentationSite is where this product's own documentation is published. One constant,
 // beside the schema $id's origin above, because the site is the product's and not a
 // deployment's: a self-hosted install reads the same published pages.
-const documentationSite = "https://docs.open-cluster.io/"
+const documentationSite = "https://docs.open-cluster.io"
 
 // ProductDocumentationURL is OUR page for this type — the one that carries the receiver
 // YAML, the header name and the version floor, rather than the vendor's reference.

--- a/internal/integrations/slack/definition.go
+++ b/internal/integrations/slack/definition.go
@@ -20,7 +20,7 @@ func Definition(client *Client, installer *Installer, servesEvents bool) integra
 			ID:   integrations.TypeSlack,
 			Key:  "slack",
 			Name: "Slack",
-			Description: "Give investigations access to Slack conversations visible " +
+			Description: "Give investigations read-only access to Slack conversations visible " +
 				"to the connected token and reply to direct app mentions in their original thread.",
 			Logo:              "slack",
 			Category:          integrations.CategoryCollaboration,

--- a/internal/investigation/agent/agent.go
+++ b/internal/investigation/agent/agent.go
@@ -88,8 +88,6 @@ type runState struct {
 	credentials  *credentialCache
 	maxRuns      int
 	maxTurns     int
-	ceiling      int
-	carried      int
 
 	runs               []investigation.ToolRun
 	executedIdentities map[string]int
@@ -211,7 +209,6 @@ func (r *Agent) Run(
 		maxRuns:            r.MaxToolRuns,
 		maxTurns:           r.MaxTurns,
 		historyBefore:      oriented.HistoryBefore,
-		ceiling:            r.deployment.ContextWindowTokens - int(r.deployment.MaxOutputTokens),
 		executedIdentities: map[string]int{},
 	}
 	if state.maxRuns <= 0 {
@@ -221,23 +218,22 @@ func (r *Agent) Run(
 		state.maxTurns = defaultMaxTurns
 	}
 	if len(messages) > 0 {
-		// UTF-8 bytes conservatively bound input tokens, with output reserved and ten percent headroom.
-		inputCapacity := state.ceiling - state.ceiling/10
-		inputBytes, err := r.initialInputBytes(oriented)
+		inputCapacity := r.deployment.ContextWindowTokens - int(r.deployment.MaxOutputTokens)
+		inputTokens, err := r.initialInputTokens(oriented)
 		if err != nil {
 			return failRun("the assigned input budget could not be established", investigation.Usage{})
 		}
-		if inputBytes > inputCapacity {
+		if inputTokens > inputCapacity {
 			oriented.Brief = &investigation.Brief{Turn: opened.Turn, Limitations: []string{
 				"Optional history and inventory were omitted to preserve the complete current request.",
 			}}
 			oriented.Inventory = nil
-			inputBytes, err = r.initialInputBytes(oriented)
+			inputTokens, err = r.initialInputTokens(oriented)
 			if err != nil {
 				return failRun("the assigned input budget could not be established", investigation.Usage{})
 			}
 		}
-		if inputBytes > inputCapacity {
+		if inputTokens > inputCapacity {
 			err := r.requestNarrowerInput(ctx, state, messages)
 			if err == nil {
 				r.RuntimeTelemetry.Ended(time.Since(startedAt), "needs_input", investigation.StoppedByContext)
@@ -249,7 +245,6 @@ func (r *Agent) Run(
 	state.missingEvidence = oriented.Brief != nil && oriented.Brief.MissingEvidence
 	state.orientationText = renderOrientation(oriented)
 	state.tools = exchangeTools(oriented)
-	state.carried = orientationTokens(oriented)
 	var priorEvidence []investigation.EvidenceRef
 	if oriented.Brief != nil {
 		for _, finding := range oriented.Brief.Findings {
@@ -277,8 +272,6 @@ func (r *Agent) Run(
 				stoppedBy = investigation.StoppedByWallClock
 			case stagnant >= maxStagnantTurns:
 				stoppedBy = investigation.StoppedByStagnation
-			case state.carried >= state.ceiling:
-				stoppedBy = investigation.StoppedByContext
 			}
 			if stoppedBy != "" {
 				r.announce(ctx, events,
@@ -304,7 +297,7 @@ func (r *Agent) Run(
 			}
 		}
 		forced := mustConclude
-		if forced {
+		forceInstruction := func() {
 			instruction := concludeInstruction(reason)
 			if len(state.transcript) == 0 {
 				state.opening = instruction
@@ -312,14 +305,47 @@ func (r *Agent) Run(
 				state.transcript[len(state.transcript)-1].Instruction = instruction
 			}
 		}
+		if forced {
+			forceInstruction()
+		}
 
 		move := modelMove{}
 		moveCtx, done := context.WithTimeout(ctx, decideTimeout)
 		for attempt := range 2 {
+			prompt, fits, budgetErr := r.budgetPrompt(modelPrompt(r, state, forced), forced)
+			if budgetErr != nil {
+				err = Failed(OutcomeRejected, r.deployment.Provider, r.deployment.Model,
+					"the provider request could not be budgeted: "+budgetErr.Error())
+				break
+			}
+			if !fits && !forced {
+				stoppedBy = investigation.StoppedByContext
+				r.announce(ctx, events, investigation.ProgressPayload(ceilingProgress(stoppedBy)))
+				reason = concludeReason(stoppedBy, len(state.offered))
+				forced = true
+				forceInstruction()
+				prompt, fits, budgetErr = r.budgetPrompt(modelPrompt(r, state, true), true)
+			}
+			if budgetErr != nil || !fits {
+				detail := "the complete provider request does not fit the model context window"
+				if budgetErr != nil {
+					detail = "the provider request could not be budgeted: " + budgetErr.Error()
+				}
+				err = Failed(OutcomeRejected, r.deployment.Provider, r.deployment.Model, detail)
+				break
+			}
 			completion, completeErr := r.telemetry.complete(
-				moveCtx, r.model, r.deployment, modelPrompt(r, state, forced))
+				moveCtx, r.model, r.deployment, prompt)
 			state.usage = state.usage.Add(usageOf(completion.Usage))
 			if completeErr != nil {
+				if attempt == 0 && !forced && errors.Is(completeErr, ErrContextWindow) {
+					stoppedBy = investigation.StoppedByContext
+					r.announce(ctx, events, investigation.ProgressPayload(ceilingProgress(stoppedBy)))
+					reason = concludeReason(stoppedBy, len(state.offered))
+					forced = true
+					forceInstruction()
+					continue
+				}
 				err = completeErr
 				break
 			}
@@ -336,7 +362,7 @@ func (r *Agent) Run(
 			}
 
 			reads, conclude := splitCalls(completion.ToolCalls)
-			if len(reads) > 0 && !mustConclude {
+			if len(reads) > 0 && !forced {
 				state.transcript = append(state.transcript, Turn{Assistant: AssistantTurn{
 					Text: string(completion.Document), Calls: completion.ToolCalls, Raw: completion.Raw,
 				}})
@@ -408,7 +434,7 @@ func (r *Agent) Run(
 			r.RuntimeTelemetry.Ended(time.Since(startedAt), investigation.StatusConcluded.String(), stoppedBy)
 			return nil
 		}
-		if mustConclude {
+		if forced {
 			terminalErr := failRun(errNoConclusion.Error(), state.usage)
 			r.RuntimeTelemetry.Ended(time.Since(startedAt), investigation.StatusFailed.String(), "")
 			return terminalErr
@@ -427,7 +453,6 @@ func (r *Agent) Run(
 					state.missingEvidence = state.missingEvidence || page.MissingEvidence
 				}
 				freshRead = freshRead || result.Run.Outcome == investigation.RunSucceeded
-				state.carried += runTokens(result.Run)
 				results = append(results, result)
 				continue
 			}
@@ -446,7 +471,6 @@ func (r *Agent) Run(
 					r.announce(ctx, events,
 						investigation.HypothesesUpdatedPayload(snapshot))
 				}
-				state.carried += runTokens(result.Run)
 				results = append(results, result)
 				continue
 			}
@@ -518,7 +542,6 @@ func (r *Agent) Run(
 			}
 			result.Run = run
 			freshRead = freshRead || fresh
-			state.carried += runTokens(result.Run)
 			results = append(results, result)
 		}
 		if freshRead {
@@ -806,44 +829,6 @@ func callIdentityOf(call toolCall) string {
 		encoded = []byte(fmt.Sprintf("%v", call.Arguments))
 	}
 	return call.Tool + " " + string(encoded)
-}
-
-// orientationTokens estimates what an orientation costs before a single read has happened.
-// The tool definitions are counted too, because a catalog of forty tools is not free and a
-// budget that ignored them would be a budget that overflowed on the tools alone.
-func orientationTokens(oriented orientation) int {
-	total := EstimateTokens(oriented.Subject) + EstimateTokens(oriented.Question)
-	for _, identity := range oriented.Inventory {
-		total += EstimateTokens(identity)
-	}
-	for _, source := range oriented.Sources {
-		total += EstimateTokens(source.Integration.Name)
-		for _, tool := range source.Tools {
-			total += EstimateTokens(tool.Name) + EstimateTokens(tool.Description) +
-				EstimateTokens(tool.WhenToUse) + EstimateTokens(tool.WhenNotToUse)
-		}
-	}
-	if oriented.Brief != nil {
-		total += briefTokens(*oriented.Brief)
-	}
-	return total
-}
-
-// runTokens estimates what feeding one result back costs. The CONTENT is what fills a
-// transcript — the summary is one line and the payload is everything the vendor returned —
-// so it is what the estimate is mostly of.
-func runTokens(run investigation.ToolRun) int {
-	total := EstimateTokens(run.Tool) + EstimateTokens(run.Summary) +
-		EstimateTokens(run.Error)
-	for _, source := range run.Sources {
-		total += EstimateTokens(source)
-	}
-	if run.Content != nil {
-		if encoded, err := json.Marshal(run.Content); err == nil {
-			total += EstimateTokens(string(encoded))
-		}
-	}
-	return total
 }
 
 // concludeReason says why reads are over, written for the model to act on.

--- a/internal/investigation/agent/agent_test.go
+++ b/internal/investigation/agent/agent_test.go
@@ -22,6 +22,7 @@ type scriptedModel struct {
 	mu    sync.Mutex
 	calls int
 	next  func(int, Prompt) (Completion, error)
+	size  func(Prompt) (int, error)
 }
 
 func (m *scriptedModel) Complete(_ context.Context, prompt Prompt) (Completion, error) {
@@ -29,6 +30,13 @@ func (m *scriptedModel) Complete(_ context.Context, prompt Prompt) (Completion, 
 	defer m.mu.Unlock()
 	m.calls++
 	return m.next(m.calls, prompt)
+}
+
+func (m *scriptedModel) RequestTokens(prompt Prompt) (int, error) {
+	if m.size != nil {
+		return m.size(prompt)
+	}
+	return EstimatePromptTokens(prompt)
 }
 
 type records struct {
@@ -711,9 +719,97 @@ func TestRunForcesAnHonestConclusionAtTheTurnLimit(t *testing.T) {
 	}
 }
 
+func TestRunForcesConclusionBeforeTheSerializedRequestExceedsContext(t *testing.T) {
+	store := &records{candidate: integrations.Integration{ID: uuid.New(), Type: 99, Name: "source"}}
+	model := &scriptedModel{
+		size: func(prompt Prompt) (int, error) {
+			if prompt.ForceTool == ConcludeToolName {
+				return 100, nil
+			}
+			return 2_000, nil
+		},
+		next: func(_ int, prompt Prompt) (Completion, error) {
+			if prompt.ForceTool != ConcludeToolName {
+				t.Fatal("an oversized provider request was sent before forcing conclusion")
+			}
+			return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{
+				ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, nil),
+			}}}, nil
+		},
+	}
+	runner := configuredTestAgent(t, store, model, testCatalog(t,
+		func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+			return integrations.ToolResult{}, nil
+		}))
+	runner.deployment.ContextWindowTokens = 1_500
+
+	organization, _ := tenancy.NewOrganization("org-test")
+	if err := runner.Run(context.Background(), organization,
+		investigation.Investigation{ID: uuid.New(), Subject: "question"}); err != nil {
+		t.Fatal(err)
+	}
+	if store.stoppedBy != investigation.StoppedByContext || model.calls != 1 {
+		t.Fatalf("stopped_by=%q calls=%d", store.stoppedBy, model.calls)
+	}
+}
+
+func TestRunRetriesAContextRejectionOnlyAsAForcedConclusion(t *testing.T) {
+	store := &records{candidate: integrations.Integration{ID: uuid.New(), Type: 99, Name: "source"}}
+	var rejectedTurns, rejectedContent []byte
+	var rejectedOutput int64
+	model := &scriptedModel{next: func(call int, prompt Prompt) (Completion, error) {
+		if call == 1 {
+			return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{ID: "read-1", Name: "stub.read", Arguments: json.RawMessage(`{"purpose":"read deployment","input":{}}`)}}}, nil
+		}
+		if call == 2 {
+			rejectedTurns, _ = json.Marshal(prompt.Turns)
+			rejectedContent, _ = json.Marshal(prompt.Content)
+			rejectedOutput = prompt.MaxOutputTokens
+			return Completion{}, FailedBecause(OutcomeRejected, "scripted", "test",
+				"context rejected", ErrContextWindow)
+		}
+		if prompt.ForceTool != ConcludeToolName {
+			t.Fatal("context rejection did not force the bounded recovery")
+		}
+		retained := append([]Turn(nil), prompt.Turns...)
+		for i := range retained {
+			retained[i].Instruction = ""
+		}
+		after, _ := json.Marshal(retained)
+		if len(prompt.Turns) == 0 || !bytes.Equal(rejectedTurns, after) {
+			t.Fatal("context recovery lost the completed tool exchange")
+		}
+		after, _ = json.Marshal(prompt.Content)
+		if !bytes.Equal(rejectedContent, after) || prompt.MaxOutputTokens > rejectedOutput {
+			t.Fatal("context recovery changed current input or increased output allowance")
+		}
+		return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{
+			ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, nil),
+		}}}, nil
+	}}
+	runner := configuredTestAgent(t, store, model, testCatalog(t,
+		func(context.Context, integrations.ToolRequest) (integrations.ToolResult, error) {
+			return integrations.ToolResult{}, nil
+		}))
+
+	organization, _ := tenancy.NewOrganization("org-test")
+	if err := runner.Run(context.Background(), organization,
+		investigation.Investigation{ID: uuid.New(), Subject: "question"}); err != nil {
+		t.Fatal(err)
+	}
+	if model.calls != 3 || store.stoppedBy != investigation.StoppedByContext {
+		t.Fatalf("calls=%d stopped_by=%q", model.calls, store.stoppedBy)
+	}
+}
+
 func TestRunReservesTheDeploymentOutputFromTheContextWindow(t *testing.T) {
-	store := &records{}
-	model := &scriptedModel{next: func(_ int, prompt Prompt) (Completion, error) {
+	store := &records{candidate: integrations.Integration{ID: uuid.New(), Type: 99, Name: "source"}}
+	model := &scriptedModel{size: func(prompt Prompt) (int, error) {
+		if prompt.ForceTool == ConcludeToolName {
+			return 1, nil
+		}
+		return 3, nil
+	}, next: func(_ int, prompt Prompt) (Completion, error) {
 		if prompt.ForceTool != ConcludeToolName {
 			t.Fatal("context window did not reserve the deployment's maximum output")
 		}
@@ -766,7 +862,15 @@ func TestRunRecordsEveryReasonThatForcesAConclusion(t *testing.T) {
 			if arguments == nil {
 				arguments = json.RawMessage(`{"purpose":"read it","input":{}}`)
 			}
-			model := &scriptedModel{next: func(_ int, prompt Prompt) (Completion, error) {
+			model := &scriptedModel{size: func(prompt Prompt) (int, error) {
+				if strings.HasPrefix(test.name, "context") {
+					if prompt.ForceTool == ConcludeToolName {
+						return 1, nil
+					}
+					return 2_000, nil
+				}
+				return 0, nil
+			}, next: func(_ int, prompt Prompt) (Completion, error) {
 				if prompt.ForceTool == ConcludeToolName {
 					return Completion{Stop: StopToolUse, ToolCalls: []CompletionCall{{
 						ID: "done", Name: ConcludeToolName, Arguments: validConclusion(t, nil),

--- a/internal/investigation/agent/anthropic/provider.go
+++ b/internal/investigation/agent/anthropic/provider.go
@@ -71,6 +71,8 @@ func classify(provider, model string, status int, identifier string, cause error
 	}
 
 	switch {
+	case status == http.StatusBadRequest && isContextLimitError(cause.Error()):
+		return reasoning.ContextRejected(provider, model, detail+": the request exceeded the model context", cause)
 	case status == http.StatusTooManyRequests:
 		return reasoning.FailedBecause(reasoning.OutcomeOutage, provider, model,
 			detail+": rate limited past the retries this deployment allows", cause)
@@ -92,6 +94,13 @@ func classify(provider, model string, status int, identifier string, cause error
 	default:
 		return reasoning.FailedBecause(reasoning.OutcomeOutage, provider, model, detail, cause)
 	}
+}
+
+func isContextLimitError(detail string) bool {
+	normalized := strings.ToLower(detail)
+	return strings.Contains(normalized, "context window") ||
+		strings.Contains(normalized, "context length") ||
+		strings.Contains(normalized, "prompt is too long")
 }
 
 func transportFailure(provider, model string, cause error) error {
@@ -157,6 +166,15 @@ func New(deployment reasoning.Deployment, options Options) (*Provider, error) {
 	}
 	requestOptions = append(requestOptions, option.WithHTTPClient(client))
 	return &Provider{client: sdk.NewClient(requestOptions...), deployment: deployment}, nil
+}
+
+// RequestTokens sizes the same provider request structure Complete sends.
+func (p *Provider) RequestTokens(prompt reasoning.Prompt) (int, error) {
+	encoded, err := json.Marshal(p.params(prompt))
+	if err != nil {
+		return 0, err
+	}
+	return reasoning.EstimateSerializedRequest(encoded), nil
 }
 
 func (p *Provider) Complete(

--- a/internal/investigation/agent/anthropic/request_budget_test.go
+++ b/internal/investigation/agent/anthropic/request_budget_test.go
@@ -1,0 +1,43 @@
+package anthropic_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	reasoning "github.com/open-cluster/oc-control-plane/internal/investigation/agent"
+	"strings"
+	"testing"
+)
+
+func TestRequestBudgetCoversTheSentBody(t *testing.T) {
+	prompt := toolPrompt()
+	prompt.System = append(prompt.System, reasoning.Block{Text: strings.Repeat("界", 1000)})
+	prompt.Tools[0].Description = strings.Repeat("schema ", 2000)
+	prompt.Turns = []reasoning.Turn{{Assistant: reasoning.AssistantTurn{Calls: []reasoning.CompletionCall{{
+		ID: "read-1", Name: prompt.Tools[0].Name, Arguments: json.RawMessage("{}"),
+	}}}, Results: []reasoning.ToolResultTurn{{CallID: "read-1", Content: strings.Repeat("result ", 1000)}}}}
+	for _, forced := range []bool{false, true} {
+		if forced {
+			prompt.ForceTool = prompt.Tools[0].Name
+		}
+		provider, wire := providerUnder(t, streamed("{}", fullUsage, "end_turn", ""))
+		estimate, err := provider.RequestTokens(prompt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := provider.Complete(context.Background(), prompt); err != nil {
+			t.Fatal(err)
+		}
+		body := wire.lastBody(t)
+		if estimate < len(body) || estimate > len(body)*2 {
+			t.Fatalf("forced=%t estimate=%d body bytes=%d", forced, estimate, len(body))
+		}
+	}
+}
+func TestContextRejectionAllowsBoundedRecovery(t *testing.T) {
+	provider, _ := providerUnder(t, failedWith(400, `{"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"prompt is too long for this context window"}}`))
+	_, err := provider.Complete(context.Background(), promptFixture())
+	if !errors.Is(err, reasoning.ErrContextWindow) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/investigation/agent/errors.go
+++ b/internal/investigation/agent/errors.go
@@ -10,11 +10,12 @@ import (
 var ErrModelUnavailable = investigation.ErrReasonerUnavailable
 
 var (
-	ErrRefused   = errors.New("the model provider declined the request")
-	ErrOutage    = errors.New("the model provider is unreachable")
-	ErrRejected  = errors.New("the model provider rejected the request as malformed")
-	ErrMalformed = errors.New("the model's answer did not satisfy the declared schema")
-	ErrTimeout   = errors.New("the model provider did not answer within the deadline")
+	ErrRefused       = errors.New("the model provider declined the request")
+	ErrOutage        = errors.New("the model provider is unreachable")
+	ErrRejected      = errors.New("the model provider rejected the request as malformed")
+	ErrMalformed     = errors.New("the model's answer did not satisfy the declared schema")
+	ErrTimeout       = errors.New("the model provider did not answer within the deadline")
+	ErrContextWindow = errors.New("the model provider rejected the request context")
 )
 
 // Outcome is which named failure happened.
@@ -109,6 +110,12 @@ func FailedBecause(outcome Outcome, provider, model, detail string, cause error)
 	return &Failure{
 		Outcome: outcome, Provider: provider, Model: model, Detail: detail, cause: cause,
 	}
+}
+
+// ContextRejected preserves the rejected-request outcome while making bounded recovery explicit.
+func ContextRejected(provider, model, detail string, cause error) *Failure {
+	return FailedBecause(OutcomeRejected, provider, model, detail,
+		errors.Join(ErrContextWindow, cause))
 }
 
 // OutcomeOf reports the named outcome behind an error, and whether there was one. An error from

--- a/internal/investigation/agent/input.go
+++ b/internal/investigation/agent/input.go
@@ -2,20 +2,15 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/open-cluster/oc-control-plane/internal/investigation"
 )
 
-func (r *Agent) initialInputBytes(oriented orientation) (int, error) {
+func (r *Agent) initialInputTokens(oriented orientation) (int, error) {
 	candidate := runState{task: taskInstruction(oriented),
 		orientationText: renderOrientation(oriented), tools: exchangeTools(oriented)}
-	encoded, err := json.Marshal(modelPrompt(r, &candidate, false))
-	if err != nil {
-		return 0, err
-	}
-	return len(encoded), nil
+	return requestTokens(r.model, modelPrompt(r, &candidate, false))
 }
 
 func (r *Agent) requestNarrowerInput(ctx context.Context, state *runState, messages []investigation.AssignedMessage) error {

--- a/internal/investigation/agent/input_test.go
+++ b/internal/investigation/agent/input_test.go
@@ -77,7 +77,14 @@ func TestAssignedBatchBeyondHistoryTailSurvivesOptionalContextTrimming(t *testin
 		store.messages = append(store.messages, investigation.AssignedMessage{Sequence: int64(n + 1), Actor: "Operator",
 			Text: fmt.Sprintf("ordered-request-%02d", n)})
 	}
-	model := &scriptedModel{next: func(_ int, prompt Prompt) (Completion, error) {
+	model := &scriptedModel{size: func(prompt Prompt) (int, error) {
+		for _, block := range prompt.Content {
+			if strings.Contains(block.Text, "old-untrusted-finding") {
+				return 40_000, nil
+			}
+		}
+		return 100, nil
+	}, next: func(_ int, prompt Prompt) (Completion, error) {
 		var text strings.Builder
 		for _, block := range prompt.Content {
 			text.WriteString(block.Text)

--- a/internal/investigation/agent/prompt.go
+++ b/internal/investigation/agent/prompt.go
@@ -484,24 +484,6 @@ func concludeInstruction(reason string) string {
 	return instruction
 }
 
-// MEASURING A TURN'S CONTEXT.
-//
-// The estimate is characters divided by a constant, and that is the whole of it. A real
-// tokenizer would be one dependency per vendor, kept in step with each vendor's releases,
-// to produce a number that is then compared against a threshold which already carries a
-// safety margin. It is deliberately pessimistic: overestimating ends a turn slightly
-// early, while underestimating can exhaust the model's context window.
-const charactersPerToken = 2
-
-// EstimateTokens reports the pessimistic token cost of some text.
-func EstimateTokens(text string) int {
-	return (len(text) + charactersPerToken - 1) / charactersPerToken
-}
-
-func briefTokens(brief investigation.Brief) int {
-	return EstimateTokens(renderBrief(&brief))
-}
-
 // conversationBrief assembles a bounded message tail and prior cited findings.
 // Optional history failure limits continuity without changing verified tool authority.
 func (r *Agent) conversationBrief(

--- a/internal/investigation/agent/request_budget.go
+++ b/internal/investigation/agent/request_budget.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type requestSizer interface {
+	RequestTokens(Prompt) (int, error)
+}
+
+// EstimateSerializedRequest counts every UTF-8 byte as one token, then adds ten percent. A token
+// cannot represent less than one byte, so this remains conservative without a vendor tokenizer.
+func EstimateSerializedRequest(encoded []byte) int {
+	base := len(encoded)
+	return base + (base+9)/10
+}
+
+// EstimatePromptTokens is the fallback for injected models without a provider encoder.
+func EstimatePromptTokens(prompt Prompt) (int, error) {
+	encoded, err := json.Marshal(prompt)
+	if err != nil {
+		return 0, fmt.Errorf("encoding the model request for budgeting: %w", err)
+	}
+	return EstimateSerializedRequest(encoded), nil
+}
+
+func requestTokens(model Model, prompt Prompt) (int, error) {
+	if sizer, ok := model.(requestSizer); ok {
+		return sizer.RequestTokens(prompt)
+	}
+	return EstimatePromptTokens(prompt)
+}
+
+func (r *Agent) budgetPrompt(prompt Prompt, mayReduceOutput bool) (Prompt, bool, error) {
+	input, err := requestTokens(r.model, prompt)
+	if err != nil {
+		return Prompt{}, false, err
+	}
+	remaining := int64(r.deployment.ContextWindowTokens - input)
+	if remaining >= prompt.MaxOutputTokens {
+		return prompt, true, nil
+	}
+	if !mayReduceOutput || remaining <= 0 {
+		return prompt, false, nil
+	}
+	prompt.MaxOutputTokens = remaining
+	input, err = requestTokens(r.model, prompt)
+	if err != nil {
+		return Prompt{}, false, err
+	}
+	remaining = int64(r.deployment.ContextWindowTokens - input)
+	if remaining <= 0 {
+		return prompt, false, nil
+	}
+	if prompt.MaxOutputTokens > remaining {
+		prompt.MaxOutputTokens = remaining
+	}
+	return prompt, true, nil
+}

--- a/internal/investigation/agent/zai/provider.go
+++ b/internal/investigation/agent/zai/provider.go
@@ -73,11 +73,14 @@ func classify(model string, status int, identifier string, payload []byte) error
 	if identifier != "" {
 		detail += " (request " + identifier + ")"
 	}
-	if message := errorMessage(payload); message != "" {
+	message := errorMessage(payload)
+	if message != "" {
 		detail += ": " + message
 	}
 
 	switch {
+	case status == http.StatusBadRequest && isContextLimitError(message):
+		return reasoning.ContextRejected(Name, model, detail, nil)
 	case status == http.StatusTooManyRequests:
 		return reasoning.Failed(reasoning.OutcomeOutage, Name, model, detail+": rate limited")
 	case status >= 500:
@@ -94,6 +97,13 @@ func classify(model string, status int, identifier string, payload []byte) error
 	default:
 		return reasoning.Failed(reasoning.OutcomeOutage, Name, model, detail)
 	}
+}
+
+func isContextLimitError(detail string) bool {
+	normalized := strings.ToLower(detail)
+	return strings.Contains(normalized, "context_length_exceeded") ||
+		strings.Contains(normalized, "context window") ||
+		strings.Contains(normalized, "context length")
 }
 
 func errorMessage(payload []byte) string {
@@ -172,6 +182,15 @@ func New(deployment reasoning.Deployment, options Options) (*Provider, error) {
 }
 
 const retryBackoff = 500 * time.Millisecond
+
+// RequestTokens sizes the same provider request structure Complete sends.
+func (p *Provider) RequestTokens(prompt reasoning.Prompt) (int, error) {
+	encoded, err := json.Marshal(p.request(prompt))
+	if err != nil {
+		return 0, err
+	}
+	return reasoning.EstimateSerializedRequest(encoded), nil
+}
 
 func (p *Provider) Complete(
 	ctx context.Context, prompt reasoning.Prompt,

--- a/internal/investigation/agent/zai/request_budget_test.go
+++ b/internal/investigation/agent/zai/request_budget_test.go
@@ -1,0 +1,43 @@
+package zai_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	reasoning "github.com/open-cluster/oc-control-plane/internal/investigation/agent"
+	"strings"
+	"testing"
+)
+
+func TestRequestBudgetCoversTheSentBody(t *testing.T) {
+	prompt := toolPrompt()
+	prompt.System = append(prompt.System, reasoning.Block{Text: strings.Repeat("界", 1000)})
+	prompt.Tools[0].Description = strings.Repeat("schema ", 2000)
+	prompt.Turns = []reasoning.Turn{{Assistant: reasoning.AssistantTurn{Calls: []reasoning.CompletionCall{{
+		ID: "read-1", Name: prompt.Tools[0].Name, Arguments: json.RawMessage("{}"),
+	}}}, Results: []reasoning.ToolResultTurn{{CallID: "read-1", Content: strings.Repeat("result ", 1000)}}}}
+	for _, forced := range []bool{false, true} {
+		if forced {
+			prompt.ForceTool = prompt.Tools[0].Name
+		}
+		provider, wire := providerUnder(t, answered(200, completion("{}", "stop", cachedUsage)))
+		estimate, err := provider.RequestTokens(prompt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := provider.Complete(context.Background(), prompt); err != nil {
+			t.Fatal(err)
+		}
+		body := wire.lastBody(t)
+		if estimate < len(body) || estimate > len(body)*2 {
+			t.Fatalf("forced=%t estimate=%d body bytes=%d", forced, estimate, len(body))
+		}
+	}
+}
+func TestContextRejectionAllowsBoundedRecovery(t *testing.T) {
+	provider, _ := providerUnder(t, answered(400, `{"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"prompt is too long for this context window"}}`))
+	_, err := provider.Complete(context.Background(), promptFixture())
+	if !errors.Is(err, reasoning.ErrContextWindow) {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
Budget every complete provider request, including schemas and prior tool exchanges, against the selected model's context and output limits. Force a bounded conclusion before overflow and allow one context-rejection recovery without dropping current input or tool pairs.

Extends issue #48 phase 5. Targets main after the refactor commits were merged in PR #73. Also repairs two verification failures inherited from refactor: a double slash in documentation URLs and Slack capability text differing from the seeded catalog.

Validation: affected agent/provider/config suites pass; focused recovery and inherited-failure regressions pass; standards and spec reviews resolved. CI passes. The full race-enabled PostgreSQL and composed-process suites pass. Full make verify found the two inherited failures fixed here; their focused reruns pass. Vulnerability and license checks pass. Release verification is running. The frontend release gate still references absent web source. No semantic model-quality claim is made.

