### PR TITLE
Remove redundant credential and unused refresh storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ outbound Relay sessions.
 
 Provider manifests own Integration catalog metadata. PostgreSQL retains stable kind codes and enforces that each
 installation belongs to an Integration of the same kind; startup does not reconcile a second catalog table.
+Credential key identity lives in the authenticated sealed envelope. Upgrades refuse retained installation
+refresh data that needs reconciliation before removing unsupported refresh fields.
 
 Provider adapters offer native read tools behind one provider-independent investigation contract. Kubernetes libraries
 and customer cluster credentials never enter this module; the Relay executes the released, versioned capability protocol

--- a/internal/store/postgres/credential_migration_test.go
+++ b/internal/store/postgres/credential_migration_test.go
@@ -1,0 +1,75 @@
+package storage_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestCredentialMigrationPreservesEnvelopesAndRefusesRetainedRefreshData(t *testing.T) {
+	ctx := context.Background()
+	dsn := postgresDSN(t)
+	connection, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = connection.Close(ctx) }()
+	baseline, err := os.ReadFile("migrations/0001_baseline.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, string(baseline)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `CREATE TABLE schema_migration(version text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now());
+INSERT INTO schema_migration(version) VALUES ('0001_baseline');
+INSERT INTO organization(org_id,display_name,created_by) VALUES ('retained-org','Retained','operator')`); err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.New()
+	if _, err := connection.Exec(ctx, `INSERT INTO integration(integration_id,org_id,integration_type_id,name,
+credential_sealed,credential_key_id,credential_fingerprint,credential_created_at)
+VALUES ($1,'retained-org',3,'Slack',decode('010203','hex'),'default','fingerprint',now())`, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `INSERT INTO integration_installation(integration_id,org_id,integration_type_id,application,workspace)
+VALUES ($1,'retained-org',3,'app','workspace')`, id); err != nil {
+		t.Fatal(err)
+	}
+	database := openDatabaseForTest(t, dsn)
+	for _, retained := range []string{"expires_at=now()", "refresh_sealed=decode('aabb','hex')"} {
+		if _, err := connection.Exec(ctx, "UPDATE integration_installation SET "+retained); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := database.Migrate(ctx); err == nil {
+			t.Fatal("upgrade discarded retained refresh data")
+		}
+		var preserved bool
+		if err := connection.QueryRow(ctx, `SELECT credential_key_id='default' AND credential_sealed=decode('010203','hex')
+FROM integration WHERE integration_id=$1`, id).Scan(&preserved); err != nil || !preserved {
+			t.Fatalf("failed upgrade changed credentials: %v", err)
+		}
+		if _, err := connection.Exec(ctx, "UPDATE integration_installation SET expires_at=NULL, refresh_sealed=NULL"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := database.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var preserved bool
+	if err := connection.QueryRow(ctx, `SELECT i.credential_sealed=decode('010203','hex')
+AND i.credential_fingerprint='fingerprint' AND s.workspace='workspace'
+FROM integration i JOIN integration_installation s USING (org_id,integration_id)
+WHERE i.integration_id=$1`, id).Scan(&preserved); err != nil || !preserved {
+		t.Fatalf("upgrade changed credential or routing: %v", err)
+	}
+	var remaining int
+	if err := connection.QueryRow(ctx, `SELECT count(*) FROM information_schema.columns WHERE table_schema='public'
+AND ((table_name='integration' AND column_name='credential_key_id')
+OR (table_name='integration_installation' AND column_name IN ('expires_at','refresh_sealed')))`).Scan(&remaining); err != nil || remaining != 0 {
+		t.Fatalf("redundant columns remain: %d, %v", remaining, err)
+	}
+}

--- a/internal/store/postgres/integration.go
+++ b/internal/store/postgres/integration.go
@@ -22,18 +22,18 @@ import (
 // contract is asserted here so a drifted method signature is a compile error.
 var _ integrations.Store = (*Database)(nil)
 
-func storedCredentialKeyID(sealed []byte) (string, error) {
+func validateCredentialEnvelope(sealed []byte) error {
 	if len(sealed) == 0 {
-		return "", nil
+		return nil
 	}
 	if sealed[0] == seal.LegacyKeyVersion {
-		return "", nil
+		return nil
 	}
-	identifier, err := seal.EnvelopeKeyID(sealed)
+	_, err := seal.EnvelopeKeyID(sealed)
 	if err != nil {
-		return "", errors.New("storing an integration credential: invalid sealed envelope")
+		return errors.New("storing an integration credential: invalid sealed envelope")
 	}
-	return identifier, nil
+	return nil
 }
 
 // integrationColumns is every column an Integration is read from, named once. One list
@@ -94,8 +94,7 @@ func (p *Database) CreateIntegration(
 				}
 			}
 
-			credentialKeyID, err := storedCredentialKeyID(wanted.CredentialSealed)
-			if err != nil {
+			if err := validateCredentialEnvelope(wanted.CredentialSealed); err != nil {
 				return integrations.Integration{}, audit.Target{}, nil, err
 			}
 			row := transaction.QueryRow(ctx, `
@@ -103,20 +102,20 @@ func (p *Database) CreateIntegration(
 				                         configuration, labels, relay_id,
 				                         webhook_secret_digest, webhook_secret_fingerprint,
 				                         webhook_secret_created_at,
-				                         credential_sealed, credential_key_id, credential_fingerprint,
+				                         credential_sealed, credential_fingerprint,
 				                         credential_created_at,
 				                         status, last_verified_at, verify_note,
 				                         verify_grants, verify_facts, created_by)
 				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
 				        CASE WHEN $8::BYTEA IS NULL THEN NULL ELSE now() END,
-				        $10, $11, $12,
+				        $10, $11,
 				        CASE WHEN $10::BYTEA IS NULL THEN NULL ELSE now() END,
-				        $13, CASE WHEN $14 THEN now() END, $15, $16, $17, $18)
+				        $12, CASE WHEN $13 THEN now() END, $14, $15, $16, $17)
 				RETURNING `+integrationColumns,
 				identityOrNew(wanted.ID), organization.String(), int16(wanted.Type), wanted.Name,
 				configuration, labels, nullableUUID(wanted.RelayID),
 				wanted.WebhookSecretDigest, nullableText(wanted.WebhookSecretFingerprint),
-				wanted.CredentialSealed, nullableText(credentialKeyID),
+				wanted.CredentialSealed,
 				nullableText(wanted.CredentialFingerprint), status, verified, note, grants, facts,
 				wanted.CreatedBy)
 
@@ -574,8 +573,7 @@ func (p *Database) ReplaceIntegrationCredential(
 			if err != nil {
 				return integrations.Integration{}, audit.Target{}, nil, err
 			}
-			credentialKeyID, err := storedCredentialKeyID(sealed)
-			if err != nil {
+			if err := validateCredentialEnvelope(sealed); err != nil {
 				return integrations.Integration{}, audit.Target{}, nil, err
 			}
 
@@ -585,21 +583,20 @@ func (p *Database) ReplaceIntegrationCredential(
 				       configuration          = coalesce($4, configuration),
 				       labels                 = coalesce($5, labels),
 				       credential_sealed      = $6,
-				       credential_key_id      = $7,
-				       credential_fingerprint = $8,
+				       credential_fingerprint = $7,
 				       credential_rotated_at  = now(),
-				       status                 = $9,
+				       status                 = $8,
 				       last_verified_at       = now(),
-				       verify_note            = $10,
-				       verify_grants          = $11,
-				       verify_facts           = $12,
+				       verify_note            = $9,
+				       verify_grants          = $10,
+				       verify_facts           = $11,
 				       updated_at             = now()
 				 WHERE integration_id = $1
 				   AND org_id = $2
 				   AND credential_sealed IS NOT NULL
 				RETURNING `+integrationColumns,
 				id, organization.String(), revision.Name, configuration, labels,
-				sealed, credentialKeyID, fingerprint, int16(verification.Status), verification.Note,
+				sealed, fingerprint, int16(verification.Status), verification.Note,
 				grants, facts)
 
 			replaced, err := scanIntegration(row, organization.String())

--- a/internal/store/postgres/migrations/0011_credential_envelope_owner.sql
+++ b/internal/store/postgres/migrations/0011_credential_envelope_owner.sql
@@ -1,0 +1,14 @@
+LOCK TABLE integration, integration_installation IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM integration_installation
+        WHERE expires_at IS NOT NULL OR refresh_sealed IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'installation has retained refresh data; reconcile credential refresh obligations before upgrading';
+    END IF;
+END $$;
+
+ALTER TABLE integration DROP COLUMN credential_key_id;
+ALTER TABLE integration_installation DROP COLUMN expires_at, DROP COLUMN refresh_sealed;

--- a/internal/store/postgres/slack_delivery_test.go
+++ b/internal/store/postgres/slack_delivery_test.go
@@ -42,7 +42,7 @@ func slackDelivery(t *testing.T, handler http.Handler) (*storage.Database, tenan
 		t.Fatal(err)
 	}
 	if _, err = pool.Exec(context.Background(), `UPDATE integration SET credential_sealed = $3,
-		credential_fingerprint = 'fixture', credential_created_at = now(), credential_key_id = 'default'
+		credential_fingerprint = 'fixture', credential_created_at = now()
 		WHERE org_id = $1 AND integration_id = $2`, org.String(), integration, sealed); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Remove redundant Integration credential-key storage while retaining key identity in the authenticated sealed envelope. Create and replace operations keep their envelope validation, credential fingerprints, timestamps, grants and facts.

A forward migration removes unused installation expiry/refresh fields only when retained rows contain no refresh data. Otherwise it refuses the upgrade before dropping columns and asks for reconciliation. Installation identity and routing remain intact.

Validation: one retained PostgreSQL migration regression, existing Slack HTTP creation/replacement tests and sealed-envelope tests pass. Standards and spec reviews are clear. CI passes. Full verification ran: PostgreSQL race suite, docs, corrected lint, build, vulnerability/license/secret checks and backend image passed. The composed suite exposed a pre-existing cancellation-test admission race, reproduced in isolation and corrected in PR #78. The known frontend image gate fails because web/ is absent; no clean release-gate claim. This depends on the compiled-catalog PR; issue #48 and the remaining phase-4 work stay open.

