### PR TITLE
Derive Slack replies from immutable Conversation routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Provider manifests own Integration catalog metadata. PostgreSQL retains stable k
 installation belongs to an Integration of the same kind; startup does not reconcile a second catalog table.
 Credential key identity lives in the authenticated sealed envelope. Upgrades refuse retained installation
 refresh data that needs reconciliation before removing unsupported refresh fields.
+Slack reply attempts derive their destination from an immutable Conversation mapping; delivery cursors and
+leases remain owned by the reply. An upgrade refuses conflicting retained destinations.
 
 Provider adapters offer native read tools behind one provider-independent investigation contract. Kubernetes libraries
 and customer cluster credentials never enter this module; the Relay executes the released, versioned capability protocol

--- a/internal/store/postgres/integration.go
+++ b/internal/store/postgres/integration.go
@@ -466,6 +466,15 @@ func (p *Database) DeleteIntegration(
 					integrations.ErrInUse, alertEvents, jobs, ledger, investigations)
 			}
 
+			// Removing the Integration retires its reply obligations atomically; a
+			// mapping cannot be removed independently while a reply still uses it.
+			if _, err := transaction.Exec(ctx, `
+				DELETE FROM slack_reply r USING slack_conversation s
+				WHERE r.org_id = $2 AND s.org_id = r.org_id
+				  AND s.conversation_id = r.conversation_id AND s.integration_id = $1`,
+				id, organization.String()); err != nil {
+				return struct{}{}, audit.Target{}, nil, fmt.Errorf("retiring integration replies: %w", err)
+			}
 			tag, err := transaction.Exec(ctx, `
 				DELETE FROM integration
 				 WHERE integration_id = $1 AND org_id = $2`,

--- a/internal/store/postgres/migrations/0012_slack_reply_routing.sql
+++ b/internal/store/postgres/migrations/0012_slack_reply_routing.sql
@@ -1,0 +1,48 @@
+LOCK TABLE slack_conversation, slack_reply, investigation IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM slack_reply r
+        LEFT JOIN slack_conversation s ON s.org_id = r.org_id AND s.conversation_id = r.conversation_id
+        LEFT JOIN investigation i ON i.org_id = r.org_id AND i.investigation_id = r.investigation_id
+        WHERE s.conversation_id IS NULL OR i.investigation_id IS NULL
+           OR i.conversation_id IS DISTINCT FROM r.conversation_id
+           OR s.integration_id <> r.integration_id
+           OR s.channel_id <> r.channel_id OR s.thread_ts <> r.thread_ts
+    ) THEN
+        RAISE EXCEPTION 'Slack reply disagrees with its Conversation routing or Investigation; reconcile retained destinations before upgrading';
+    END IF;
+END $$;
+
+ALTER TABLE slack_conversation
+    ADD CONSTRAINT slack_conversation_identity_is_org_scoped UNIQUE (org_id, conversation_id);
+
+ALTER TABLE investigation
+    ADD CONSTRAINT investigation_identity_in_conversation UNIQUE (org_id, conversation_id, investigation_id);
+
+ALTER TABLE slack_reply
+    ADD CONSTRAINT slack_reply_names_its_mapping FOREIGN KEY (org_id, conversation_id)
+        REFERENCES slack_conversation (org_id, conversation_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT slack_reply_names_its_conversation_investigation FOREIGN KEY (org_id, conversation_id, investigation_id)
+        REFERENCES investigation (org_id, conversation_id, investigation_id) ON DELETE CASCADE,
+    DROP CONSTRAINT slack_reply_investigation_is_in_the_same_org,
+    DROP COLUMN integration_id,
+    DROP COLUMN channel_id,
+    DROP COLUMN thread_ts;
+
+CREATE FUNCTION prevent_slack_conversation_retargeting() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF (NEW.org_id, NEW.conversation_id, NEW.integration_id, NEW.channel_id, NEW.thread_ts)
+        IS DISTINCT FROM (OLD.org_id, OLD.conversation_id, OLD.integration_id, OLD.channel_id, OLD.thread_ts) THEN
+        RAISE EXCEPTION 'Slack Conversation routing is immutable';
+    END IF;
+    RETURN NEW;
+END $$;
+
+CREATE TRIGGER slack_conversation_routing_is_immutable
+    BEFORE UPDATE ON slack_conversation
+    FOR EACH ROW EXECUTE FUNCTION prevent_slack_conversation_retargeting();
+
+DROP INDEX slack_conversation_by_thread;

--- a/internal/store/postgres/slack_reply.go
+++ b/internal/store/postgres/slack_reply.go
@@ -38,9 +38,8 @@ const (
 func oweSlackReplies(ctx context.Context, pool *pgxpool.Pool, limit int) error {
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO slack_reply
-			(investigation_id, org_id, integration_id, conversation_id, channel_id, thread_ts)
-		SELECT i.investigation_id, i.org_id, s.integration_id, i.conversation_id,
-		       s.channel_id, s.thread_ts
+			(investigation_id, org_id, conversation_id)
+		SELECT i.investigation_id, i.org_id, i.conversation_id
 		  FROM investigation i
 		  JOIN slack_conversation s
 		    ON s.org_id = i.org_id AND s.conversation_id = i.conversation_id
@@ -68,6 +67,7 @@ func (p *Database) ClaimSlackReplies(
 		return nil, err
 	}
 	rows, err := p.pool.Query(ctx, `
+		WITH claimed AS (
 			UPDATE slack_reply
 			   SET status       = $1,
 			       lease_owner  = gen_random_uuid(),
@@ -82,8 +82,14 @@ func (p *Database) ClaimSlackReplies(
 			        ORDER BY next_attempt_at
 			        LIMIT $4
 			          FOR UPDATE SKIP LOCKED)
-			RETURNING investigation_id, org_id, integration_id, conversation_id,
-			          channel_id, thread_ts, stream_ts, native, last_sequence, attempts, lease_owner, leased_until`,
+			RETURNING investigation_id, org_id, conversation_id,
+			          stream_ts, native, last_sequence, attempts, lease_owner, leased_until
+		)
+		SELECT c.investigation_id, c.org_id, s.integration_id, c.conversation_id,
+		       s.channel_id, s.thread_ts, c.stream_ts, c.native, c.last_sequence,
+		       c.attempts, c.lease_owner, c.leased_until
+		FROM claimed c JOIN slack_conversation s
+		  ON s.org_id = c.org_id AND s.conversation_id = c.conversation_id`,
 		SlackReplyDelivering, lease.String(), SlackReplyPending, limit)
 	if err != nil {
 		return nil, fmt.Errorf("claiming slack replies: %w", err)

--- a/internal/store/postgres/slack_reply_test.go
+++ b/internal/store/postgres/slack_reply_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/open-cluster/oc-control-plane/internal/auth/tenancy"
 	"github.com/open-cluster/oc-control-plane/internal/conversation"
+	"github.com/open-cluster/oc-control-plane/internal/integrations"
 	"github.com/open-cluster/oc-control-plane/internal/integrations/slack"
 	"github.com/open-cluster/oc-control-plane/internal/store/postgres"
 )
@@ -109,6 +111,38 @@ func TestEveryTurnOfASlackConversationOwesAnAnswer(t *testing.T) {
 	}
 	if one.Stream.TS != "" || one.LastSequence != 0 {
 		t.Errorf("a fresh delivery already claims progress: %+v", one)
+	}
+}
+
+func TestSlackReplyCannotBeRetargetedBetweenAttempts(t *testing.T) {
+	database, organization := migratedDatabase(t)
+	ctx := context.Background()
+	investigation, integration := aSlackTurn(t, database, organization, "T-ORIGINAL", "C-ORIGINAL", "1700000001.1")
+	reply := claimed(t, database, investigation, time.Minute)
+	pool, err := database.Pool(organization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE slack_conversation SET channel_id='C-OTHER'
+WHERE org_id=$1 AND conversation_id=$2`, organization.String(), reply.Conversation); err == nil {
+		t.Fatal("pending reply destination was retargeted")
+	}
+	if err := database.RetrySlackReply(ctx, organization, investigation, reply.ClaimToken,
+		time.Now().Add(-time.Second), "retry", false); err != nil {
+		t.Fatal(err)
+	}
+	retried := claimed(t, database, investigation, time.Minute)
+	if retried.Integration != integration || retried.Stream.Channel != "C-ORIGINAL" || retried.Stream.Thread != "1700000001.1" {
+		t.Fatalf("retry changed destination: %+v", retried)
+	}
+	if err := database.CompleteSlackReply(ctx, organization, investigation, retried.ClaimToken); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.DeleteIntegration(ctx, ownerOf(t, organization), organization, integration); !errors.Is(err, integrations.ErrInUse) {
+		t.Fatalf("outstanding Webhook Work did not prevent disconnection: %v", err)
+	}
+	if _, _, _, _, found, err := database.SlackReplyState(ctx, organization, investigation); err != nil || !found {
+		t.Fatalf("refused disconnection removed reply state: found=%v, %v", found, err)
 	}
 }
 

--- a/internal/store/postgres/slack_routing_migration_test.go
+++ b/internal/store/postgres/slack_routing_migration_test.go
@@ -1,0 +1,96 @@
+package storage_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestSlackRoutingMigrationPreservesProgressAndRefusesConflictingDestinations(t *testing.T) {
+	ctx := context.Background()
+	dsn := postgresDSN(t)
+	connection, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = connection.Close(ctx) }()
+	baseline, err := os.ReadFile("migrations/0001_baseline.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, string(baseline)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `CREATE TABLE schema_migration(version text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now());
+INSERT INTO schema_migration(version) VALUES ('0001_baseline');
+INSERT INTO organization(org_id,display_name,created_by) VALUES ('retained-org','Retained','operator')`); err != nil {
+		t.Fatal(err)
+	}
+	integration, conversation, investigation := uuid.New(), uuid.New(), uuid.New()
+	if _, err := connection.Exec(ctx, `INSERT INTO integration(integration_id,org_id,integration_type_id,name)
+VALUES ($1,'retained-org',3,'Slack')`, integration); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `INSERT INTO conversation(conversation_id,org_id,subject,surface)
+VALUES ($1,'retained-org','Retained Slack thread',2)`, conversation); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `INSERT INTO investigation(investigation_id,org_id,subject,conversation_id,turn,window_from,window_until)
+VALUES ($1,'retained-org','Retained question',$2,1,now()-interval '1 hour',now())`, investigation, conversation); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `INSERT INTO slack_conversation(conversation_id,org_id,integration_id,channel_id,thread_ts)
+VALUES ($1,'retained-org',$2,'C-ORIGINAL','1700000001.1')`, conversation, integration); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(ctx, `INSERT INTO slack_reply(investigation_id,org_id,integration_id,conversation_id,
+channel_id,thread_ts,status,last_sequence,stream_ts,native,attempts,note)
+VALUES ($1,'retained-org',$2,$3,'C-WRONG','1700000001.1',1,12,'1700000002.1',true,2,'retry')`, investigation, integration, conversation); err != nil {
+		t.Fatal(err)
+	}
+	database := openDatabaseForTest(t, dsn)
+	if _, err := database.Migrate(ctx); err == nil {
+		t.Fatal("upgrade accepted a conflicting retained destination")
+	}
+	var channel string
+	if err := connection.QueryRow(ctx, `SELECT channel_id FROM slack_reply WHERE investigation_id=$1`, investigation).Scan(&channel); err != nil || channel != "C-WRONG" {
+		t.Fatalf("failed migration changed the retained route: %q %v", channel, err)
+	}
+	if _, err := connection.Exec(ctx, `UPDATE slack_reply SET channel_id='C-ORIGINAL' WHERE investigation_id=$1`, investigation); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if applied, err := database.Migrate(ctx); err != nil || len(applied) != 0 {
+		t.Fatalf("repeated migration: %v %v", applied, err)
+	}
+	reply := claimed(t, database, investigation, time.Minute)
+	if reply.Integration != integration || reply.Conversation != conversation || reply.Stream.Channel != "C-ORIGINAL" ||
+		reply.Stream.Thread != "1700000001.1" || reply.Stream.TS != "1700000002.1" || !reply.Stream.Native ||
+		reply.LastSequence != 12 || reply.Attempts != 2 {
+		t.Fatalf("upgrade changed delivery destination or progress: %+v", reply)
+	}
+	for _, statement := range []string{
+		`DELETE FROM slack_conversation WHERE conversation_id=$1`,
+		`UPDATE investigation SET conversation_id=NULL,turn=NULL WHERE conversation_id=$1`,
+	} {
+		if _, err := connection.Exec(ctx, statement, conversation); err == nil {
+			t.Fatalf("reply ownership could be removed: %s", statement)
+		}
+	}
+	org := organization(t, "retained-org")
+	if err := database.CompleteSlackReply(ctx, org, investigation, reply.ClaimToken); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.DeleteIntegration(ctx, ownerOf(t, org), org, integration); err != nil {
+		t.Fatalf("completed reply prevented disconnection: %v", err)
+	}
+	if _, _, _, _, found, err := database.SlackReplyState(ctx, org, investigation); err != nil || found {
+		t.Fatalf("disconnection retained reply state: found=%v, %v", found, err)
+	}
+}

--- a/test/controlplane/event_lifecycle_test.go
+++ b/test/controlplane/event_lifecycle_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestEventStreamClosesAfterTerminalCursor(t *testing.T) {
-	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	plane, _ := agentPlane(t, &blockingAgentMain{})
 	_, turn := plane.openConversation(t, "replayed stream", "investigate checkout")
 	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations/"+turn+"/cancel", nil)
 	if status != http.StatusOK {
@@ -37,7 +37,7 @@ func TestEventStreamClosesAfterTerminalCursor(t *testing.T) {
 }
 
 func TestEventStreamClosesDuringGracefulShutdown(t *testing.T) {
-	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	plane, _ := agentPlane(t, &blockingAgentMain{})
 	_, turn := plane.openConversation(t, "shutdown stream", "investigate checkout")
 	response := openEventStream(t, plane, turn, "")
 	defer func() { _ = response.Body.Close() }()
@@ -52,13 +52,13 @@ func TestEventStreamClosesDuringGracefulShutdown(t *testing.T) {
 
 func TestEventStreamSurvivesOrdinaryWriteTimeout(t *testing.T) {
 	t.Parallel()
-	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	plane, _ := agentPlane(t, &blockingAgentMain{})
 	assertLiveEventStream(t, plane, plane)
 }
 
 func TestEventStreamThroughSupportedProxy(t *testing.T) {
 	t.Parallel()
-	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	plane, _ := agentPlane(t, &blockingAgentMain{})
 	proxied := *plane
 	proxied.operator = startEventProxy(t, plane.operator)
 	assertLiveEventStream(t, plane, &proxied)

--- a/test/controlplane/event_schema_test.go
+++ b/test/controlplane/event_schema_test.go
@@ -46,7 +46,7 @@ func TestFailedEventMatchesSerializedSchema(t *testing.T) {
 }
 
 func TestCancelledEventMatchesSerializedSchema(t *testing.T) {
-	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	plane, _ := agentPlane(t, &blockingAgentMain{})
 	_, turn := plane.openConversation(t, "cancel schema", "investigate checkout")
 	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations/"+turn+"/cancel", nil)
 	if status != http.StatusOK {

--- a/test/controlplane/event_slow_reader_test.go
+++ b/test/controlplane/event_slow_reader_test.go
@@ -32,7 +32,7 @@ func TestEventStreamBoundsSlowReaders(t *testing.T) {
 				digest := sha256.Sum256([]byte(surfaceToken))
 				cfg.OperatorTokenDigest = digest[:]
 				dsn = cfg.DatabaseDSN
-			}, app.Options{Agent: &blockingAgentMain{started: make(chan struct{}, 1)}})
+			}, app.Options{Agent: &blockingAgentMain{}})
 			plane := &integrationPlane{controlPlane: running, operator: address, intake: address}
 			_, turn := plane.openConversation(t, "large replay", "investigate checkout")
 			seedEventBacklog(t, dsn, turn)

--- a/test/controlplane/investigation_cancellation_test.go
+++ b/test/controlplane/investigation_cancellation_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 type blockingAgentMain struct {
-	started chan struct{}
+	started chan uuid.UUID
 }
 
 func (b *blockingAgentMain) Run(
-	ctx context.Context, _ tenancy.Organization, _ investigation.Investigation,
+	ctx context.Context, _ tenancy.Organization, running investigation.Investigation,
 ) error {
 	select {
-	case b.started <- struct{}{}:
+	case b.started <- running.ID:
 	default:
 	}
 	<-ctx.Done()
@@ -31,24 +31,17 @@ func (b *blockingAgentMain) Run(
 func TestRunningInvestigationCanBeCancelledThroughTheAuthorizedOperatorSurface(t *testing.T) {
 	t.Parallel()
 
-	model := &blockingAgentMain{started: make(chan struct{}, 1)}
+	model := &blockingAgentMain{started: make(chan uuid.UUID, 1)}
 	plane, _ := agentPlane(t, model)
 	incident := plane.openIncident(t, "CheckoutLatency", "cancel-running")
-	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations",
-		map[string]any{"incidentId": incident})
-	if status != http.StatusAccepted {
-		t.Fatalf("opening an investigation = %d: %s", status, body)
-	}
-	var opened struct {
-		ID string `json:"id"`
-	}
-	decodeInto(t, body, &opened)
+	var runningID string
 	select {
-	case <-model.started:
+	case id := <-model.started:
+		runningID = id.String()
 	case <-time.After(10 * time.Second):
 		t.Fatal("the investigation never reached its active model exchange")
 	}
-	status, body = plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations",
+	status, body := plane.call(t, http.MethodPost, plane.base(surfaceOrg)+"/investigations",
 		map[string]any{"incidentId": incident})
 	if status != http.StatusAccepted {
 		t.Fatalf("work was refused merely because the worker was busy: %d: %s", status, body)
@@ -58,7 +51,7 @@ func TestRunningInvestigationCanBeCancelledThroughTheAuthorizedOperatorSurface(t
 	if status != http.StatusTooManyRequests {
 		t.Fatalf("work above the pending backlog was not refused: %d: %s", status, body)
 	}
-	path := plane.base(surfaceOrg) + "/investigations/" + opened.ID + "/cancel"
+	path := plane.base(surfaceOrg) + "/investigations/" + runningID + "/cancel"
 	status, body = plane.call(t, http.MethodPost, path, nil)
 	if status != http.StatusOK {
 		t.Fatalf("cancelling an active investigation = %d: %s", status, body)
@@ -73,7 +66,7 @@ func TestRunningInvestigationCanBeCancelledThroughTheAuthorizedOperatorSurface(t
 	if status, body = plane.call(t, http.MethodPost, path, nil); status != http.StatusConflict {
 		t.Fatalf("cancelling a terminal investigation = %d, want 409: %s", status, body)
 	}
-	foreign := plane.base(neighbourOrg) + "/investigations/" + opened.ID + "/cancel"
+	foreign := plane.base(neighbourOrg) + "/investigations/" + runningID + "/cancel"
 	if status, body = plane.call(t, http.MethodPost, foreign, nil); status != http.StatusNotFound {
 		t.Fatalf("cross-organization cancellation = %d, want 404: %s", status, body)
 	}
@@ -82,7 +75,7 @@ func TestRunningInvestigationCanBeCancelledThroughTheAuthorizedOperatorSurface(t
 func TestDirectInvestigationCreationRequiresOnlyAnIncidentIdentity(t *testing.T) {
 	t.Parallel()
 
-	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan struct{}, 1)})
+	plane, _ := agentPlane(t, &blockingAgentMain{started: make(chan uuid.UUID, 1)})
 	path := plane.base(surfaceOrg) + "/investigations"
 
 	if status, body := plane.call(t, http.MethodPost, path,


### PR DESCRIPTION
Slack replies now derive their destination from the canonical Conversation mapping. A forward migration refuses conflicting retained destinations, adds exact Organization/Conversation/Investigation relationships, prevents mapping retargeting, and removes copied Integration/channel/thread columns plus the redundant thread index.

Reply leases, stream identity, cursors and retry progress remain independent. Integration disconnection retires its replies in the existing audited transaction; standalone mapping removal stays restricted, and refused disconnection rolls back cleanup.

Validation: two focused PostgreSQL regressions cover immutable retry destinations, upgrade refusal/preservation, repeated migration, relationship constraints, successful disconnection and rollback when Webhook Work still depends on the Integration. Existing claim/disconnection tests pass. Standards/spec review found a deletion regression; it is fixed and re-reviewed. Full verification ran: PostgreSQL race suite, docs, lint, builds, vulnerability/license/secret checks and backend image pass. The composed suite had an Alertmanager resolution timeout that passed unchanged on an isolated race rerun. A pre-existing cancellation-test admission race found in the preceding run was corrected to cancel the actual running Investigation; its race rerun and reviews pass. The known frontend gate still fails because Frontend.Dockerfile copies absent web/ source. E2E module returns success, but live Relay cases lack the expected source checkout; no version-pair compatibility claim.

Catalog and credential-storage dependencies are merged. This completes another phase-4 slice; issue #48 remains open.

